### PR TITLE
fix: target only h2 for vine effect

### DIFF
--- a/docs/css/effects.css
+++ b/docs/css/effects.css
@@ -95,3 +95,48 @@ html body div#SITE_CONTAINER div div#site-root.site-root div#masterPage.mesh-lay
     }
 }
 
+/* Styles for the Vine Growth effect */
+
+#greenhouse-title-for-vine-effect.vine-effect-active {
+    position: relative;
+    color: transparent;
+}
+
+#greenhouse-title-for-vine-effect.vine-effect-active span {
+    display: inline-block;
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.5s ease, transform 0.5s ease;
+}
+
+#greenhouse-title-for-vine-effect.vine-effect-active.animation-running span {
+    opacity: 1;
+    transform: translateY(0);
+    color: #333; /* Restore text color */
+}
+
+/* The SVG element that will contain the vine path */
+.vine-svg {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 100%;
+    height: 150%; /* Taller than the text to allow the vine to grow outside the text box */
+    overflow: visible;
+    z-index: -1; /* Ensures the vine is drawn behind the text */
+}
+
+/* The vine path itself */
+.vine-path {
+    stroke-width: 3px;
+    stroke: #357438; /* A nice green color for the vine */
+    fill: none;
+    /* The dasharray and dashoffset will be set by JavaScript to match the path length */
+    transition: stroke-dashoffset 4s ease-in-out;
+}
+
+/* When the animation is running, the dashoffset is animated to 0, a drawing the vine */
+.vine-effect-active.animation-running .vine-path {
+    stroke-dashoffset: 0;
+}

--- a/docs/js/effects.js
+++ b/docs/js/effects.js
@@ -378,3 +378,103 @@
     };
 
 })();
+
+(function() {
+    'use strict';
+
+    const config = {
+        elementWaitTimeout: 10000,
+        textToFind: "GREENHOUSE FOR MENTAL HEALTH DEVELOPMENT",
+        idToApply: "greenhouse-title-for-vine-effect"
+    };
+
+    function waitForElementByText(text, timeout = config.elementWaitTimeout) {
+        return new Promise((resolve, reject) => {
+            const findElement = () => {
+                const allElements = document.querySelectorAll('h2');
+                for (let i = 0; i < allElements.length; i++) {
+                    if (allElements[i].textContent.trim().toUpperCase() === text) {
+                        return allElements[i];
+                    }
+                }
+                return null;
+            };
+
+            let element = findElement();
+            if (element) {
+                resolve(element);
+                return;
+            }
+
+            const observer = new MutationObserver(() => {
+                element = findElement();
+                if (element) {
+                    observer.disconnect();
+                    resolve(element);
+                }
+            });
+
+            observer.observe(document.body, {
+                childList: true,
+                subtree: true,
+                characterData: true
+            });
+
+            setTimeout(() => {
+                observer.disconnect();
+                reject(new Error(`Element with text "${text}" not found.`));
+            }, timeout);
+        });
+    }
+
+    async function activateVineEffect() {
+        try {
+            const heading = await waitForElementByText(config.textToFind);
+            if (!heading || heading.dataset.vineInitialized === 'true') return;
+
+            heading.id = config.idToApply;
+            heading.dataset.originalText = heading.textContent;
+            heading.dataset.vineInitialized = 'true';
+            heading.classList.add('vine-effect-active');
+
+            heading.innerHTML = heading.dataset.originalText.split('').map(char => {
+                return `<span>${char === ' ' ? '&nbsp;' : char}</span>`;
+            }).join('');
+
+            const svgNS = "http://www.w3.org/2000/svg";
+            const svg = document.createElementNS(svgNS, "svg");
+            svg.setAttribute("class", "vine-svg");
+            svg.setAttribute("viewBox", "0 0 800 120");
+
+            const path = document.createElementNS(svgNS, "path");
+            path.setAttribute("class", "vine-path");
+            path.setAttribute("d", "M10,110 C150,-30 250,150 400,60 S550,-30 700,60 S790,100 790,100");
+
+            svg.appendChild(path);
+            heading.appendChild(svg);
+
+            const pathLength = path.getTotalLength();
+            path.style.strokeDasharray = pathLength;
+            path.style.strokeDashoffset = pathLength;
+
+            setTimeout(() => {
+                heading.classList.add('animation-running');
+            }, 100);
+
+        } catch (error) {
+            console.error('Vine Effect Error:', error);
+        }
+    }
+
+    function initialize() {
+        activateVineEffect();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', initialize);
+    } else {
+        // Give Wix a moment to finish rendering
+        setTimeout(initialize, 500);
+    }
+
+})();


### PR DESCRIPTION
Updates the vine effect script to only search for `h2` elements with the target text, 'Greenhouse for Mental Health Development'.

This corrects an issue where the effect could be misapplied to other elements, such as `h1`, that contain the same text.