### PR TITLE
Corrected the `loadScript` function call in `docs/js/greenhouse.js` b…

### DIFF
--- a/docs/js/greenhouse.js
+++ b/docs/js/greenhouse.js
@@ -212,7 +212,7 @@
         console.log('Greenhouse: Initializing application loader');
         
         // Load the visual effects script on all pages (no need to wait for specific elements)
-        GreenhouseUtils.loadScript(`${config.githubPagesBaseUrl}js/effects.js`);
+        GreenhouseUtils.loadScript('effects.js', config.githubPagesBaseUrl);
 
         // Check if the current page is the schedule page.
         if (window.location.pathname.includes(config.schedulePagePath)) {


### PR DESCRIPTION
…y passing the script name and base URL as separate arguments.