### PR TITLE
Fix(scheduler): Correct patient view initialization logic

### DIFF
--- a/docs/js/greenhouse.js
+++ b/docs/js/greenhouse.js
@@ -160,23 +160,12 @@
 
         console.log(`Greenhouse: Loading scheduler for view: ${view}`);
 
-        if (view === 'dashboard') {
-            // Dashboard view has two panels (schedule/conflicts and calendar)
-            await loadApplication(
-                'scheduler',
-                'scheduler.js',
-                config.selectors.dashboardLeft,
-                config.fallbackSelectors.dashboardLeft,
-                'schedulerUI.js',
-                'dashboard', // Explicitly pass view
-                config.selectors.dashboardRight,
-                config.fallbackSelectors.dashboardRight
-            );
-        } else {
-            // Patient and Admin views have a single panel.
-            // Determine the correct selector based on the view.
-            const mainSelector = (view === 'admin') ? config.selectors.admin : config.selectors.patient;
-            const fallbackSelector = (view === 'admin') ? config.fallbackSelectors.admin : config.fallbackSelectors.patient;
+        if (view === 'dashboard' || view === 'patient') {
+            // Dashboard and Patient views have two panels.
+            const mainSelector = (view === 'dashboard') ? config.selectors.dashboardLeft : config.selectors.patient;
+            const fallbackSelector = (view === 'dashboard') ? config.fallbackSelectors.dashboardLeft : config.fallbackSelectors.patient;
+            const rightPanelSelector = config.selectors.dashboardRight; // Use dashboard's right selector for both
+            const rightPanelFallbackSelector = config.fallbackSelectors.dashboardRight;
 
             await loadApplication(
                 'scheduler',
@@ -184,7 +173,22 @@
                 mainSelector,
                 fallbackSelector,
                 'schedulerUI.js',
-                view, // Pass the current view ('patient' or 'admin')
+                view, // Pass the current view
+                rightPanelSelector,
+                rightPanelFallbackSelector
+            );
+        } else {
+            // Admin view has a single panel.
+            const mainSelector = config.selectors.admin;
+            const fallbackSelector = config.fallbackSelectors.admin;
+
+            await loadApplication(
+                'scheduler',
+                'scheduler.js',
+                mainSelector,
+                fallbackSelector,
+                'schedulerUI.js',
+                'admin', // Pass the admin view
                 null, // No right panel selector for single-panel views
                 null  // No right panel fallback selector
             );


### PR DESCRIPTION
The scheduler was failing to load for the 'patient' view due to a TypeError, which was caused by the application attempting to access properties of a null DOM element.

The root cause was in `greenhouse.js`, where the `loadSchedulerApplication` function incorrectly assumed that the 'patient' view was a single-panel layout. This resulted in the right-hand panel's selector not being passed during initialization. The downstream application logic in `GreenhousePatientApp.js` and `schedulerUI.js` correctly expects a two-panel layout and crashed when the right-hand panel was not found.

This commit corrects the logic in `greenhouse.js` to treat the 'patient' view as a two-panel layout, similar to the 'dashboard' view. It now provides the necessary selectors for both the left and right panels, ensuring that the application initializes correctly and preventing the crash.