### PR TITLE
Fix race condition in GreenhousePatientApp.js.

### DIFF
--- a/docs/js/GreenhousePatientApp.js
+++ b/docs/js/GreenhousePatientApp.js
@@ -488,9 +488,11 @@ const GreenhousePatientApp = (function() {
         }
 
 
-        // Load initial data
-        await populateServices();
-        await populateAppointments();
+        // Load initial data after a delay to allow the UI to render first.
+        setTimeout(async () => {
+            await populateServices();
+            await populateAppointments();
+        }, 1000); // 1-second delay
         resetForm(); // Ensure form is in a clean state
     }
 


### PR DESCRIPTION
The application was attempting to fetch data for services and appointments immediately upon initialization, which caused errors because the UI elements were not yet rendered.

This change wraps the data loading calls (`populateServices` and `populateAppointments`) in a `setTimeout` with a 1-second delay. This ensures that the UI has sufficient time to render before the data is fetched, resolving the race condition as per the user's request.