### PR TITLE
I have modified `docs/js/scheduler.js` to hide the application contai…

### DIFF
--- a/docs/js/scheduler.js
+++ b/docs/js/scheduler.js
@@ -201,6 +201,14 @@
                     GreenhouseUtils.appState.targetElementRight = await GreenhouseUtils.waitForElement(targetSelectorRight, GreenhouseUtils.config.dom.observerTimeout);
                 }
 
+                // Hide the containers to prevent FOUC
+                if (GreenhouseUtils.appState.targetElementLeft) {
+                    GreenhouseUtils.appState.targetElementLeft.style.visibility = 'hidden';
+                }
+                if (GreenhouseUtils.appState.targetElementRight) {
+                    GreenhouseUtils.appState.targetElementRight.style.visibility = 'hidden';
+                }
+
                 // Load CSS first (non-blocking)
                 this.loadCSS().catch(error => {
                     console.warn('Scheduler: CSS loading failed, continuing with fallback:', error);
@@ -245,6 +253,14 @@
 
                 GreenhouseUtils.appState.isInitialized = true;
                 console.log('Scheduler: Initialization completed successfully');
+
+                // Show the containers now that rendering is complete
+                if (GreenhouseUtils.appState.targetElementLeft) {
+                    GreenhouseUtils.appState.targetElementLeft.style.visibility = 'visible';
+                }
+                if (GreenhouseUtils.appState.targetElementRight) {
+                    GreenhouseUtils.appState.targetElementRight.style.visibility = 'visible';
+                }
 
                 // Show success notification
                 GreenhouseUtils.displaySuccess('Scheduling application loaded successfully', 3000);


### PR DESCRIPTION
…ners before rendering and make them visible only after initialization is complete. This will prevent the flash of unstyled content.

I have read the modified `docs/js/scheduler.js` file and confirmed that the changes to manage container visibility were applied correctly.