### PR TITLE
Structure-first 3D visuals: morphology, regional surface noise, synaptic & DNA geometry

### DIFF
--- a/docs/js/genetic/genetic_ui_3d_dna.js
+++ b/docs/js/genetic/genetic_ui_3d_dna.js
@@ -100,33 +100,33 @@
                     const midX = (p1.x + p2.x) / 2;
                     const midY = (p1.y + p2.y) / 2;
 
-                    // Get base pair colors from config
-                    const baseColors = config.get('materials.dna.baseColors');
                     const type = (i / 2) % 4;
-                    let color1, color2;
+                    const isPurineWide = type < 2;
+                    const rungThickness = thickness * (isPurineWide ? 1.15 : 0.9);
+                    const rungTwist = ((i / 2) * (Math.PI / 5)) % (Math.PI * 2);
+                    const tx = Math.cos(rungTwist);
+                    const ty = Math.sin(rungTwist);
+                    const edgeNx = (p2.y - p1.y);
+                    const edgeNy = -(p2.x - p1.x);
+                    const edgeLen = Math.sqrt(edgeNx * edgeNx + edgeNy * edgeNy) || 1;
+                    const nx = edgeNx / edgeLen;
+                    const ny = edgeNy / edgeLen;
+                    const rx = tx * 0.6 + nx * 0.4;
+                    const ry = ty * 0.6 + ny * 0.4;
 
-                    switch (type) {
-                        case 0: color1 = baseColors.A; color2 = baseColors.T; break;
-                        case 1: color1 = baseColors.T; color2 = baseColors.A; break;
-                        case 2: color1 = baseColors.C; color2 = baseColors.G; break;
-                        case 3: color1 = baseColors.G; color2 = baseColors.C; break;
-                    }
-
-                    // Enhanced cylinder drawing with lighting
-                    const drawEnhancedCylinder = (x1, y1, x2, y2, color, depth) => {
-                        // Calculate normal for lighting (perpendicular to line)
+                    // Enhanced structural rung drawing with lighting.
+                    const drawStructuralRung = (x1, y1, x2, y2, depth) => {
                         const dx = x2 - x1;
                         const dy = y2 - y1;
                         const len = Math.sqrt(dx * dx + dy * dy);
-                        const nx = -dy / len;
-                        const ny = dx / len;
+                        const nxLine = -dy / len;
+                        const nyLine = dx / len;
 
-                        // Apply lighting if available
-                        let litColor = color;
+                        let litColor = '#d8def4';
                         if (lighting) {
-                            const baseColor = lighting.parseColor(color);
+                            const baseColor = lighting.parseColor('#b8c8ff');
                             const material = config.get('materials.dna');
-                            const normal = { x: nx, y: ny, z: 0 };
+                            const normal = { x: nxLine, y: nyLine, z: 0 };
                             const position = { x: (x1 + x2) / 2, y: (y1 + y2) / 2, z: depth };
 
                             const lit = lighting.calculateLighting(normal, position, camera, {
@@ -141,37 +141,50 @@
                             litColor = lighting.toRGBA(lit);
                         }
 
-                        // Draw main cylinder with gradient for 3D effect
+                        // Draw as a flattened rectangular beam to encode base pair geometry.
                         const gradient = ctx.createLinearGradient(
-                            x1 - nx * thickness / 2, y1 - ny * thickness / 2,
-                            x1 + nx * thickness / 2, y1 + ny * thickness / 2
+                            x1 - rx * rungThickness / 2, y1 - ry * rungThickness / 2,
+                            x1 + rx * rungThickness / 2, y1 + ry * rungThickness / 2
                         );
-                        gradient.addColorStop(0, 'rgba(0, 0, 0, 0.5)'); // Darker Shadow edge
-                        gradient.addColorStop(0.3, litColor); // Main color
-                        gradient.addColorStop(0.7, litColor); // Main color
-                        gradient.addColorStop(1, 'rgba(255, 255, 255, 0.6)'); // Brighter Highlight edge
+                        gradient.addColorStop(0, 'rgba(25, 30, 50, 0.55)');
+                        gradient.addColorStop(0.3, litColor);
+                        gradient.addColorStop(0.7, litColor);
+                        gradient.addColorStop(1, 'rgba(255, 255, 255, 0.6)');
 
                         ctx.strokeStyle = gradient;
-                        ctx.lineWidth = thickness;
-                        ctx.lineCap = 'butt'; // Butt cap for clean join at middle
+                        ctx.lineWidth = rungThickness;
+                        ctx.lineCap = 'butt';
                         ctx.beginPath();
                         ctx.moveTo(x1, y1);
                         ctx.lineTo(x2, y2);
                         ctx.stroke();
 
-                        // Add specular highlight
+                        // Structural hatch marks for grayscale distinguishability.
+                        const hatchCount = isPurineWide ? 3 : 2;
+                        ctx.strokeStyle = 'rgba(255,255,255,0.45)';
+                        ctx.lineWidth = Math.max(1, rungThickness * 0.08);
+                        for (let h = 1; h <= hatchCount; h++) {
+                            const t = h / (hatchCount + 1);
+                            const hx = x1 + dx * t;
+                            const hy = y1 + dy * t;
+                            ctx.beginPath();
+                            ctx.moveTo(hx - nxLine * rungThickness * 0.32, hy - nyLine * rungThickness * 0.32);
+                            ctx.lineTo(hx + nxLine * rungThickness * 0.32, hy + nyLine * rungThickness * 0.32);
+                            ctx.stroke();
+                        }
+
                         ctx.strokeStyle = 'rgba(255, 255, 255, 0.7)';
-                        ctx.lineWidth = thickness * 0.2;
+                        ctx.lineWidth = rungThickness * 0.16;
                         ctx.beginPath();
-                        ctx.moveTo(x1 + nx * thickness * 0.15, y1 + ny * thickness * 0.15);
-                        ctx.lineTo(x2 + nx * thickness * 0.15, y2 + ny * thickness * 0.15);
+                        ctx.moveTo(x1 + nxLine * rungThickness * 0.15, y1 + nyLine * rungThickness * 0.15);
+                        ctx.lineTo(x2 + nxLine * rungThickness * 0.15, y2 + nyLine * rungThickness * 0.15);
                         ctx.stroke();
                     };
 
-                    // Draw two halves with depth
+                    // Draw two halves with depth (still linked to A/T/C/G data, but geometry first).
                     const avgDepth = (p1.depth + p2.depth) / 2;
-                    drawEnhancedCylinder(p1.x, p1.y, midX, midY, color1, avgDepth);
-                    drawEnhancedCylinder(midX, midY, p2.x, p2.y, color2, avgDepth);
+                    drawStructuralRung(p1.x, p1.y, midX, midY, avgDepth);
+                    drawStructuralRung(midX, midY, p2.x, p2.y, avgDepth);
                 }
             }
 

--- a/docs/js/genetic/genetic_ui_3d_geometry.js
+++ b/docs/js/genetic/genetic_ui_3d_geometry.js
@@ -19,11 +19,14 @@
             const strandOffset = strandIndex === 0 ? 0 : 2.2;
 
             const angle = t + strandOffset;
+            const groovePhase = (pairIndex % 10) / 10;
+            const majorGrooveLift = Math.sin(groovePhase * Math.PI * 2) * 3.5;
+            const grooveRadius = radius + (strandIndex === 0 ? majorGrooveLift : -majorGrooveLift * 0.6);
 
             // 3D Spiral: x = r*cos(t), z = r*sin(t), y = t
-            const x = helixOffset + Math.cos(angle) * radius;
+            const x = helixOffset + Math.cos(angle) * grooveRadius;
             const y = (pairIndex * verticalSpread) - 300;
-            const z = Math.sin(angle) * radius;
+            const z = Math.sin(angle) * grooveRadius;
 
             return { x, y, z, strandIndex };
         },

--- a/docs/js/neuro/neuro_ui_3d_geometry.js
+++ b/docs/js/neuro/neuro_ui_3d_geometry.js
@@ -156,6 +156,41 @@
             return { vertices, faces };
         },
 
+        inferRegionFromUnitPosition(x, y, z) {
+            if (y < -0.5 && Math.abs(x) < 0.3 && Math.abs(z) < 0.3) return 'brainstem';
+            if (y < -0.3 && z < -0.4) return 'cerebellum';
+            if (z > 0.4 && y > -0.2) return 'pfc';
+            if (z < -0.5 && y > -0.2) return 'occipitalLobe';
+            if (y > 0.4 && z > -0.4 && z < 0.4) return 'parietalLobe';
+            if (Math.abs(x) > 0.4 && y < 0.1 && z > -0.4 && z < 0.4) return 'temporalLobe';
+            if (Math.abs(x) < 0.3 && Math.abs(y) < 0.3 && Math.abs(z) < 0.3) return 'amygdala';
+            if (Math.abs(x) > 0.2 && Math.abs(x) < 0.5 && y < 0 && z > -0.2 && z < 0.2) return 'hippocampus';
+            return null;
+        },
+
+        getRegionalSurfaceNoise(region, x, y, z) {
+            switch (region) {
+                case 'pfc':
+                    return Math.sin(x * 18) * Math.cos(y * 18) * 0.02 + Math.sin(z * 26) * 0.012;
+                case 'temporalLobe':
+                    return Math.sin(z * 12) * Math.cos(x * 6) * 0.028 + Math.sin(y * 9) * 0.01;
+                case 'occipitalLobe':
+                    return Math.sin(y * 8) * Math.cos(z * 8) * 0.023;
+                case 'parietalLobe':
+                    return Math.sin(x * 14) * Math.cos(z * 14) * 0.022;
+                case 'cerebellum':
+                    return (Math.sin(z * 40) * 0.022) + (Math.sin(z * 20) * 0.018);
+                case 'brainstem':
+                    return Math.sin(y * 4) * 0.006;
+                case 'hippocampus':
+                    return Math.sin((x + z) * 16) * 0.016;
+                case 'amygdala':
+                    return Math.sin((x * x + y * y + z * z) * 10) * 0.012;
+                default:
+                    return Math.sin(x * 10) * Math.cos(y * 10) * Math.sin(z * 10) * 0.012;
+            }
+        },
+
         initializeBrainShell(brainShell) {
             // Use realistic brain mesh if available
             if (window.GreenhouseBrainMeshRealistic) {
@@ -228,10 +263,11 @@
                         }
                     }
 
-                    // 5. Gyri/Sulci Noise (The brain surface 'wrinkles')
-                    // Using layered sine waves to remove the 'soccer ball' look
-                    const noise = (Math.sin(x * 12) * Math.cos(y * 12) * Math.sin(z * 12)) * 0.03 +
-                        (Math.sin(x * 25) * Math.cos(y * 25)) * 0.01;
+                    // 5. Region-specific gyri/sulci morphology (structure-first)
+                    const regionKey = this.inferRegionFromUnitPosition(x, y, z);
+                    const baseNoise = (Math.sin(x * 12) * Math.cos(y * 12) * Math.sin(z * 12)) * 0.016;
+                    const regionalNoise = this.getRegionalSurfaceNoise(regionKey, x, y, z);
+                    const noise = baseNoise + regionalNoise;
 
                     x = x * radius * (1 + noise);
                     y = y * radius * (1 + noise);
@@ -245,21 +281,13 @@
                     const u = 1 - (lon / longitudeBands);
                     const v = 1 - (lat / latitudeBands);
 
-                    // Add Gyri Texture (Visual only, affects lighting)
-                    // We can bake this into the normal or color later
-                    let texture = 0;
-                    if (window.GreenhouseModels3DMath && window.GreenhouseModels3DMath.noise) {
-                        // If we had a noise function...
-                    } else {
-                        // Simple procedural texture
-                        texture = (Math.sin(x * 0.1) + Math.cos(y * 0.1) + Math.sin(z * 0.1)) * 0.5 + 0.5;
-                    }
-
-                    // Apply texture to geometry (displacement mapping)
-                    if (texture > 0.6) {
-                        x += (x / len) * 2;
-                        y += (y / len) * 2;
-                        z += (z / len) * 2;
+                    // Displacement map now adapts to inferred anatomical area.
+                    const texture = (Math.sin(x * 0.1) + Math.cos(y * 0.1) + Math.sin(z * 0.1)) * 0.5 + 0.5;
+                    const textureLift = regionKey === 'cerebellum' ? 1.2 : 0.8;
+                    if (texture > 0.58) {
+                        x += (x / len) * textureLift;
+                        y += (y / len) * textureLift;
+                        z += (z / len) * textureLift;
                     }
 
                     brainShell.vertices.push({ x, y, z });
@@ -328,6 +356,29 @@
 
             // Pre-calculate Regions and Boundaries
             this.computeRegionsAndBoundaries(brainShell);
+        },
+
+        updateMesh(geometry, time, state = {}) {
+            if (!geometry || !Array.isArray(geometry.vertices)) return geometry;
+            const load = Math.max(0, Math.min(1, state.cognitiveLoad ?? state.load ?? 0));
+            const tension = Math.max(0, Math.min(1, state.tension ?? 0));
+
+            geometry.vertices.forEach((v, idx) => {
+                if (v.baseX === undefined) {
+                    v.baseX = v.x;
+                    v.baseY = v.y;
+                    v.baseZ = v.z;
+                }
+                const regionNoise = this.getRegionalSurfaceNoise(v.region, v.baseX / 200, v.baseY / 200, v.baseZ / 200);
+                const osc = Math.sin(time * 0.0018 + idx * 0.13) * (0.8 + load);
+                const displacement = regionNoise * (3.2 + load * 4.5) + osc * tension * 0.9;
+                const len = Math.sqrt(v.baseX * v.baseX + v.baseY * v.baseY + v.baseZ * v.baseZ) || 1;
+                v.x = v.baseX + (v.baseX / len) * displacement;
+                v.y = v.baseY + (v.baseY / len) * displacement;
+                v.z = v.baseZ + (v.baseZ / len) * displacement;
+            });
+
+            return geometry;
         },
 
         getRegionVertices(brainShell, regionKey) {

--- a/docs/js/neuro/neuro_ui_3d_neuron.js
+++ b/docs/js/neuro/neuro_ui_3d_neuron.js
@@ -2,78 +2,77 @@
     'use strict';
 
     const GreenhouseNeuroNeuron = {
-        neuronMeshes: {}, // Cache for neuron meshes
+        neuronMeshes: {},
 
         drawNeuron(ctx, neuron, camera, projection, colorOverride, pulseFreq = 0.005) {
-            // Project Center for LOD and Culling
             const p = GreenhouseModels3DMath.project3DTo2D(neuron.x, neuron.y, neuron.z, camera, projection);
-
-            // Culling
             if (p.scale <= 0) return;
 
-            // LOD: Low Detail (Simple Circle) for distant neurons
-            if (p.scale < 0.6) {
-                const alpha = GreenhouseModels3DMath.applyDepthFog(1, p.depth);
-                ctx.save();
-                ctx.globalAlpha = alpha;
-                ctx.fillStyle = colorOverride || neuron.baseColor;
-                ctx.beginPath();
-                ctx.arc(p.x, p.y, neuron.radius * p.scale, 0, Math.PI * 2);
-                ctx.fill();
-                ctx.restore();
+            const pyramidalRegions = ['pfc', 'temporalLobe', 'parietalLobe', 'occipitalLobe', 'hippocampus'];
+            const type = pyramidalRegions.includes(neuron.region) ? 'pyramidal' : 'stellate';
+            const lod = p.scale < 0.3 ? 0 : p.scale < 0.6 ? 1 : 2;
+
+            if (lod === 0) {
+                this.drawLODIcon(ctx, p, neuron, type, colorOverride);
                 return;
             }
 
-            // High Detail: 3D Mesh
-            // Determine cell type based on region
-            const pyramidalRegions = ['pfc', 'temporalLobe', 'parietalLobe', 'occipitalLobe', 'hippocampus'];
-            const type = pyramidalRegions.includes(neuron.region) ? 'pyramidal' : 'stellate';
-
-            // Get or generate base mesh
-            if (!this.neuronMeshes[type]) {
-                this.neuronMeshes[type] = type === 'pyramidal' ?
-                    this.generatePyramidalMesh() :
-                    this.generateStellateMesh();
+            const meshKey = `${type}_lod${lod}`;
+            if (!this.neuronMeshes[meshKey]) {
+                this.neuronMeshes[meshKey] = type === 'pyramidal'
+                    ? this.generatePyramidalMesh(lod)
+                    : this.generateStellateMesh(lod);
             }
-            const mesh = this.neuronMeshes[type];
+            const mesh = this.neuronMeshes[meshKey];
 
-            // Transform vertices to world space (Rotation + Translation)
+            const now = Date.now();
+            const activation = Math.max(0, Math.min(1, neuron.activationLevel ?? neuron.activation ?? 0));
+            const neuronSeed = String(neuron.id ?? `${neuron.x}_${neuron.y}_${neuron.z}`)
+                .split('')
+                .reduce((acc, ch) => acc + ch.charCodeAt(0), 0);
+            const firingOsc = Math.max(0, Math.sin(now * 0.02 + neuronSeed * 0.01));
+            const firingPulse = (neuron.isFiring || activation > 0.85) ? firingOsc * 0.12 : 0;
+            const membraneDisplacement = activation * 0.8;
+
             const rotX = neuron.x * 0.01;
-            const rotY = neuron.y * 0.01 + Date.now() * (pulseFreq * 0.1); // Scalable rotation
+            const rotY = neuron.y * 0.01 + now * (pulseFreq * 0.1);
             const rotZ = neuron.z * 0.01;
 
-            const transformedVertices = mesh.vertices.map(v => {
-                // Rotate
-                let x = v.x, y = v.y, z = v.z;
+            const transformedVertices = mesh.vertices.map((v) => {
+                let x = v.x;
+                let y = v.y;
+                let z = v.z;
 
-                // Rotate Y
+                if (v.isSoma) {
+                    const flicker = Math.sin((x * 0.35 + y * 0.25 + z * 0.3) + now * 0.012 + neuronSeed * 0.02);
+                    const bump = 1 + membraneDisplacement * 0.06 * flicker + firingPulse;
+                    x *= bump;
+                    y *= bump;
+                    z *= bump;
+                }
+
                 let tx = x * Math.cos(rotY) - z * Math.sin(rotY);
                 let tz = x * Math.sin(rotY) + z * Math.cos(rotY);
                 x = tx; z = tz;
 
-                // Rotate X
                 let ty = y * Math.cos(rotX) - z * Math.sin(rotX);
                 tz = y * Math.sin(rotX) + z * Math.cos(rotX);
                 y = ty; z = tz;
 
-                // Scale
-                const scale = type === 'pyramidal' ? 1.5 : 1.0;
+                tx = x * Math.cos(rotZ) - y * Math.sin(rotZ);
+                ty = x * Math.sin(rotZ) + y * Math.cos(rotZ);
+                x = tx; y = ty;
+
+                const scale = type === 'pyramidal' ? 1.3 : 1.05;
                 x *= scale; y *= scale; z *= scale;
 
-                // Translate to Neuron Position (World Space)
-                return {
-                    x: x + neuron.x,
-                    y: y + neuron.y,
-                    z: z + neuron.z
-                };
+                return { x: x + neuron.x, y: y + neuron.y, z: z + neuron.z };
             });
 
-            // Project to 2D
             const projected = transformedVertices.map(v =>
                 GreenhouseModels3DMath.project3DTo2D(v.x, v.y, v.z, camera, projection)
             );
 
-            // Sort faces
             const facesWithDepth = mesh.faces.map(face => {
                 const v1 = projected[face[0]];
                 const v2 = projected[face[1]];
@@ -81,139 +80,248 @@
 
                 if (v1.scale > 0 && v2.scale > 0 && v3.scale > 0) {
                     return {
-                        face,
                         depth: (v1.depth + v2.depth + v3.depth) / 3,
                         vertices: [v1, v2, v3],
                         origVertices: [transformedVertices[face[0]], transformedVertices[face[1]], transformedVertices[face[2]]]
                     };
                 }
                 return null;
-            }).filter(f => f !== null).sort((a, b) => b.depth - a.depth);
+            }).filter(Boolean).sort((a, b) => b.depth - a.depth);
 
-            // Light Direction
             const lightDir = { x: 0.5, y: -0.5, z: 1 };
             const len = Math.sqrt(lightDir.x * lightDir.x + lightDir.y * lightDir.y + lightDir.z * lightDir.z);
             lightDir.x /= len; lightDir.y /= len; lightDir.z /= len;
 
-            // Draw Faces
-            // Use depth from first face or neuron center?
-            // Ideally average depth of face.
-
             facesWithDepth.forEach(({ vertices, origVertices, depth }) => {
                 const [v1, v2, v3] = vertices;
                 const [ov1, ov2, ov3] = origVertices;
-
                 const alpha = GreenhouseModels3DMath.applyDepthFog(1, depth);
 
-                // Backface Culling
                 const dx1 = v2.x - v1.x;
                 const dy1 = v2.y - v1.y;
                 const dx2 = v3.x - v1.x;
                 const dy2 = v3.y - v1.y;
-                const cross = dx1 * dy2 - dy1 * dx2;
+                if (dx1 * dy2 - dy1 * dx2 <= 0) return;
 
-                if (cross > 0) {
-                    // Calculate Normal
-                    const ux = ov2.x - ov1.x;
-                    const uy = ov2.y - ov1.y;
-                    const uz = ov2.z - ov1.z;
-                    const vx = ov3.x - ov1.x;
-                    const vy = ov3.y - ov1.y;
-                    const vz = ov3.z - ov1.z;
+                const ux = ov2.x - ov1.x;
+                const uy = ov2.y - ov1.y;
+                const uz = ov2.z - ov1.z;
+                const vx = ov3.x - ov1.x;
+                const vy = ov3.y - ov1.y;
+                const vz = ov3.z - ov1.z;
 
-                    let nx = uy * vz - uz * vy;
-                    let ny = uz * vx - ux * vz;
-                    let nz = ux * vy - uy * vx;
-                    const nLen = Math.sqrt(nx * nx + ny * ny + nz * nz);
+                let nx = uy * vz - uz * vy;
+                let ny = uz * vx - ux * vz;
+                let nz = ux * vy - uy * vx;
+                const nLen = Math.sqrt(nx * nx + ny * ny + nz * nz);
 
-                    let intensity = 0.4; // Ambient
-                    if (nLen > 0) {
-                        nx /= nLen; ny /= nLen; nz /= nLen;
-                        const diffuse = Math.max(0, nx * lightDir.x + ny * lightDir.y + nz * lightDir.z);
-                        intensity += diffuse * 0.6;
-                    }
-
-                    // Apply Lighting to Base Color
-                    const colorStr = (typeof colorOverride === 'string') ? colorOverride :
-                                   (typeof neuron.baseColor === 'string') ? neuron.baseColor : '#ffffff';
-                    const colorMatch = colorStr.match(/#([0-9a-f]{6})/i);
-                    let r = 255, g = 255, b = 255;
-                    if (colorMatch) {
-                        const hex = parseInt(colorMatch[1], 16);
-                        r = (hex >> 16) & 255;
-                        g = (hex >> 8) & 255;
-                        b = hex & 255;
-                    }
-
-                    const litR = Math.min(255, r * intensity);
-                    const litG = Math.min(255, g * intensity);
-                    const litB = Math.min(255, b * intensity);
-
-                    ctx.fillStyle = `rgba(${litR}, ${litG}, ${litB}, ${alpha})`;
-                    ctx.beginPath();
-                    ctx.moveTo(v1.x, v1.y);
-                    ctx.lineTo(v2.x, v2.y);
-                    ctx.lineTo(v3.x, v3.y);
-                    ctx.fill();
+                let intensity = 0.4;
+                if (nLen > 0) {
+                    nx /= nLen; ny /= nLen; nz /= nLen;
+                    const diffuse = Math.max(0, nx * lightDir.x + ny * lightDir.y + nz * lightDir.z);
+                    intensity += diffuse * 0.6;
                 }
+
+                const colorStr = (typeof colorOverride === 'string') ? colorOverride : (typeof neuron.baseColor === 'string' ? neuron.baseColor : '#ffffff');
+                const colorMatch = colorStr.match(/#([0-9a-f]{6})/i);
+                let r = 235, g = 242, b = 255;
+                if (colorMatch) {
+                    const hex = parseInt(colorMatch[1], 16);
+                    r = (hex >> 16) & 255;
+                    g = (hex >> 8) & 255;
+                    b = hex & 255;
+                }
+
+                const litR = Math.min(255, r * intensity);
+                const litG = Math.min(255, g * intensity);
+                const litB = Math.min(255, b * intensity);
+
+                ctx.fillStyle = `rgba(${litR}, ${litG}, ${litB}, ${alpha})`;
+                ctx.beginPath();
+                ctx.moveTo(v1.x, v1.y);
+                ctx.lineTo(v2.x, v2.y);
+                ctx.lineTo(v3.x, v3.y);
+                ctx.fill();
             });
         },
 
-        generatePyramidalMesh() {
-            // True 3D Pyramid: Base triangle + Apex + Elongated Apical Dendrite
-            const r = 6;
-            const h = 12;
-            const vertices = [
-                { x: 0, y: -h, z: 0 }, // 0: Apex (Top)
-                { x: r, y: r, z: r },  // 1: Base 1
-                { x: -r, y: r, z: r }, // 2: Base 2
-                { x: 0, y: r, z: -r }  // 3: Base 3
-            ];
-            const faces = [
-                [0, 1, 2], // Side 1
-                [0, 2, 3], // Side 2
-                [0, 3, 1], // Side 3
-                [1, 3, 2]  // Base
-            ];
-            return { vertices, faces };
+        drawLODIcon(ctx, p, neuron, type, colorOverride) {
+            const alpha = GreenhouseModels3DMath.applyDepthFog(1, p.depth);
+            const radius = Math.max(1.2, neuron.radius * p.scale * 0.9);
+            const stroke = colorOverride || neuron.baseColor || '#dbeafe';
+
+            ctx.save();
+            ctx.globalAlpha = alpha;
+            ctx.lineWidth = Math.max(1, p.scale * 1.5);
+            ctx.strokeStyle = stroke;
+            ctx.fillStyle = 'rgba(255,255,255,0.14)';
+
+            if (type === 'pyramidal') {
+                ctx.beginPath();
+                ctx.moveTo(p.x, p.y - radius * 1.6);
+                ctx.lineTo(p.x + radius * 1.35, p.y + radius * 1.2);
+                ctx.lineTo(p.x - radius * 1.35, p.y + radius * 1.2);
+                ctx.closePath();
+                ctx.fill();
+                ctx.stroke();
+            } else {
+                ctx.beginPath();
+                ctx.arc(p.x, p.y, radius, 0, Math.PI * 2);
+                ctx.fill();
+                ctx.stroke();
+
+                const rays = 6;
+                for (let i = 0; i < rays; i++) {
+                    const angle = (i / rays) * Math.PI * 2;
+                    const x1 = p.x + Math.cos(angle) * radius;
+                    const y1 = p.y + Math.sin(angle) * radius;
+                    const x2 = p.x + Math.cos(angle) * radius * 1.8;
+                    const y2 = p.y + Math.sin(angle) * radius * 1.8;
+                    ctx.beginPath();
+                    ctx.moveTo(x1, y1);
+                    ctx.lineTo(x2, y2);
+                    ctx.stroke();
+                }
+            }
+
+            ctx.restore();
         },
 
-        generateStellateMesh() {
-            // True 3D Star (Icosahedron-like spike ball)
-            // Simplified: Central cube with pyramids on each face
-            const s = 4; // size
-            const p = 8; // spike length
-            const vertices = [
-                // Cube Vertices (0-7)
-                { x: -s, y: -s, z: -s }, { x: s, y: -s, z: -s }, { x: s, y: s, z: -s }, { x: -s, y: s, z: -s },
-                { x: -s, y: -s, z: s }, { x: s, y: -s, z: s }, { x: s, y: s, z: s }, { x: -s, y: s, z: s },
-                // Spikes (8-13)
-                { x: 0, y: 0, z: -s - p }, // Back
-                { x: 0, y: 0, z: s + p },  // Front
-                { x: 0, y: -s - p, z: 0 }, // Top
-                { x: 0, y: s + p, z: 0 },  // Bottom
-                { x: -s - p, y: 0, z: 0 }, // Left
-                { x: s + p, y: 0, z: 0 }   // Right
+        appendSphere(vertices, faces, center, radius, latBands = 8, lonBands = 8) {
+            const base = vertices.length;
+            for (let lat = 0; lat <= latBands; lat++) {
+                const theta = (lat / latBands) * Math.PI;
+                const sinT = Math.sin(theta);
+                const cosT = Math.cos(theta);
+                for (let lon = 0; lon <= lonBands; lon++) {
+                    const phi = (lon / lonBands) * Math.PI * 2;
+                    vertices.push({
+                        x: center.x + radius * Math.cos(phi) * sinT,
+                        y: center.y + radius * cosT,
+                        z: center.z + radius * Math.sin(phi) * sinT,
+                        isSoma: true
+                    });
+                }
+            }
+            for (let lat = 0; lat < latBands; lat++) {
+                for (let lon = 0; lon < lonBands; lon++) {
+                    const row = lonBands + 1;
+                    const a = base + lat * row + lon;
+                    const b = a + row;
+                    faces.push([a, b, a + 1]);
+                    faces.push([b, b + 1, a + 1]);
+                }
+            }
+        },
+
+        appendTaperedBranch(vertices, faces, start, end, rStart, rEnd, segments = 6) {
+            const base = vertices.length;
+            let tx = end.x - start.x;
+            let ty = end.y - start.y;
+            let tz = end.z - start.z;
+            const tLen = Math.sqrt(tx * tx + ty * ty + tz * tz) || 1;
+            tx /= tLen; ty /= tLen; tz /= tLen;
+
+            let ux = 0, uy = 1, uz = 0;
+            if (Math.abs(ty) > 0.9) { ux = 1; uy = 0; uz = 0; }
+
+            let bx = ty * uz - tz * uy;
+            let by = tz * ux - tx * uz;
+            let bz = tx * uy - ty * ux;
+            const bLen = Math.sqrt(bx * bx + by * by + bz * bz) || 1;
+            bx /= bLen; by /= bLen; bz /= bLen;
+
+            let nx = by * tz - bz * ty;
+            let ny = bz * tx - bx * tz;
+            let nz = bx * ty - by * tx;
+
+            const rings = [
+                { p: start, r: rStart },
+                { p: end, r: rEnd }
             ];
 
+            rings.forEach(ring => {
+                for (let i = 0; i < segments; i++) {
+                    const th = (i / segments) * Math.PI * 2;
+                    const cos = Math.cos(th);
+                    const sin = Math.sin(th);
+                    vertices.push({
+                        x: ring.p.x + ring.r * (nx * cos + bx * sin),
+                        y: ring.p.y + ring.r * (ny * cos + by * sin),
+                        z: ring.p.z + ring.r * (nz * cos + bz * sin),
+                        isSoma: false
+                    });
+                }
+            });
+
+            for (let i = 0; i < segments; i++) {
+                const a = base + i;
+                const b = base + (i + 1) % segments;
+                const c = base + segments + (i + 1) % segments;
+                const d = base + segments + i;
+                faces.push([a, b, c]);
+                faces.push([a, c, d]);
+            }
+        },
+
+        generatePyramidalMesh(lod = 2) {
+            const vertices = [];
             const faces = [];
-            // Add faces for spikes connecting to cube corners...
-            // Simplified for performance: Just a few spikes
-            // Top Spike
-            faces.push([10, 0, 1], [10, 1, 5], [10, 5, 4], [10, 4, 0]);
-            // Bottom Spike
-            faces.push([11, 3, 2], [11, 2, 6], [11, 6, 7], [11, 7, 3]);
-            // Front Spike
-            faces.push([9, 4, 5], [9, 5, 6], [9, 6, 7], [9, 7, 4]);
-            // Back Spike
-            faces.push([8, 1, 0], [8, 0, 3], [8, 3, 2], [8, 2, 1]);
-            // Left Spike
-            faces.push([12, 0, 4], [12, 4, 7], [12, 7, 3], [12, 3, 0]);
-            // Right Spike
-            faces.push([13, 5, 1], [13, 1, 2], [13, 2, 6], [13, 6, 5]);
+
+            this.appendSphere(vertices, faces, { x: 0, y: 0, z: 0 }, lod === 1 ? 5.5 : 7.5, lod === 1 ? 5 : 8, lod === 1 ? 5 : 8);
+
+            const apicalEnd = { x: 0, y: lod === 1 ? 18 : 42, z: 0 };
+            this.appendTaperedBranch(vertices, faces, { x: 0, y: 7, z: 0 }, apicalEnd, 1.8, 0.8, 6);
+
+            if (lod >= 2) {
+                const basalEnds = [
+                    { x: 16, y: -5, z: 10 }, { x: -17, y: -4, z: 8 }, { x: 10, y: -6, z: -16 }, { x: -11, y: -5, z: -15 }
+                ];
+                basalEnds.forEach((end, idx) => {
+                    const root = { x: end.x * 0.25, y: -2, z: end.z * 0.25 };
+                    this.appendTaperedBranch(vertices, faces, root, end, 1.6, 0.75, 6);
+
+                    const forkA = { x: end.x + (idx % 2 ? -7 : 7), y: end.y + 7, z: end.z + 5 };
+                    const forkB = { x: end.x + (idx % 2 ? 6 : -6), y: end.y + 5, z: end.z - 6 };
+                    this.appendTaperedBranch(vertices, faces, end, forkA, 0.75, 0.45, 5);
+                    this.appendTaperedBranch(vertices, faces, end, forkB, 0.75, 0.45, 5);
+                });
+
+                this.appendTaperedBranch(vertices, faces, { x: 0, y: -6.5, z: 0 }, { x: 0, y: -20, z: 0 }, 1.5, 0.4, 5);
+            }
 
             return { vertices, faces };
         },
+
+        generateStellateMesh(lod = 2) {
+            const vertices = [];
+            const faces = [];
+
+            this.appendSphere(vertices, faces, { x: 0, y: 0, z: 0 }, lod === 1 ? 5 : 6.2, lod === 1 ? 5 : 7, lod === 1 ? 5 : 7);
+
+            const primary = lod === 1
+                ? [{ x: 0, y: 18, z: 0 }]
+                : [
+                    { x: 0, y: 22, z: 0 }, { x: 0, y: -22, z: 0 }, { x: 20, y: 2, z: 0 }, { x: -20, y: -1, z: 0 },
+                    { x: 0, y: 3, z: 20 }, { x: 0, y: -3, z: -20 }, { x: 14, y: 14, z: -10 }, { x: -14, y: -13, z: 10 }
+                ];
+
+            primary.forEach((end) => {
+                const start = { x: end.x * 0.2, y: end.y * 0.2, z: end.z * 0.2 };
+                this.appendTaperedBranch(vertices, faces, start, end, 1.4, 0.55, 5);
+
+                if (lod >= 2) {
+                    const spineA = { x: end.x + 2.5, y: end.y + 1.5, z: end.z };
+                    const spineB = { x: end.x - 2.2, y: end.y - 1.1, z: end.z + 1.8 };
+                    const spineC = { x: end.x, y: end.y + 1.8, z: end.z - 2.4 };
+                    this.appendSphere(vertices, faces, spineA, 1.1, 4, 4);
+                    this.appendSphere(vertices, faces, spineB, 1.0, 4, 4);
+                    this.appendSphere(vertices, faces, spineC, 1.0, 4, 4);
+                }
+            });
+
+            return { vertices, faces };
+        }
     };
 
     window.GreenhouseNeuroNeuron = GreenhouseNeuroNeuron;

--- a/docs/js/neuro/neuro_ui_3d_synapse.js
+++ b/docs/js/neuro/neuro_ui_3d_synapse.js
@@ -25,6 +25,51 @@
 
         drawConnections(ctx, connections, neurons, camera, projection, width, height) {
             const now = Date.now();
+            const drawStructuralConnectionCue = (from, to, weight, alpha) => {
+                const dx = to.x - from.x;
+                const dy = to.y - from.y;
+                const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+                const ux = dx / dist;
+                const uy = dy / dist;
+                const nx = -uy;
+                const ny = ux;
+
+                const tipX = to.x - ux * Math.min(8, dist * 0.25);
+                const tipY = to.y - uy * Math.min(8, dist * 0.25);
+
+                ctx.fillStyle = `rgba(255,255,255,${Math.min(0.9, alpha + 0.15)})`;
+                ctx.beginPath();
+                ctx.moveTo(to.x, to.y);
+                ctx.lineTo(tipX + nx * 3.5, tipY + ny * 3.5);
+                ctx.lineTo(tipX - nx * 3.5, tipY - ny * 3.5);
+                ctx.closePath();
+                ctx.fill();
+
+                if (Math.abs(weight) > 0.7) {
+                    ctx.strokeStyle = `rgba(255,255,255,${Math.min(0.7, alpha + 0.1)})`;
+                    ctx.lineWidth = 1.25;
+                    for (let i = 1; i <= 3; i++) {
+                        const t = i / 4;
+                        const cx = from.x + dx * t;
+                        const cy = from.y + dy * t;
+                        const seg = 4;
+                        ctx.beginPath();
+                        ctx.moveTo(cx - ux * seg + nx * 1.4, cy - uy * seg + ny * 1.4);
+                        ctx.lineTo(cx + ux * seg + nx * 1.4, cy + uy * seg + ny * 1.4);
+                        ctx.stroke();
+                    }
+                } else if (Math.abs(weight) < 0.3) {
+                    ctx.strokeStyle = `rgba(255,255,255,${Math.min(0.5, alpha)})`;
+                    ctx.lineWidth = 0.8;
+                    ctx.setLineDash([2, 3]);
+                    ctx.beginPath();
+                    ctx.moveTo(from.x, from.y);
+                    ctx.lineTo(to.x, to.y);
+                    ctx.stroke();
+                    ctx.setLineDash([]);
+                }
+            };
+
             const lightDir = { x: 0.5, y: -0.5, z: 1 };
             const len = Math.sqrt(lightDir.x * lightDir.x + lightDir.y * lightDir.y + lightDir.z * lightDir.z);
             lightDir.x /= len; lightDir.y /= len; lightDir.z /= len;
@@ -60,6 +105,7 @@
                     if (!batches[key]) batches[key] = new Path2D();
                     batches[key].moveTo(p1.x, p1.y);
                     batches[key].lineTo(p2.x, p2.y);
+                    drawStructuralConnectionCue(p1, p2, conn.weight, alpha);
                     continue;
                 }
 
@@ -186,6 +232,8 @@
                         ctx.restore();
                     }
                 }
+
+                drawStructuralConnectionCue(p1, p2, conn.weight, alpha);
             }
 
             ctx.lineWidth = 1;


### PR DESCRIPTION
### Motivation
- Replace color-dominant cues with shape, surface detail, and motion so biological identity and state are readable in grayscale and accessible displays.
- Make neurons, brain regions, synapses and DNA encode information via geometry, texture and animation rather than relying primarily on color.
- Introduce runtime geometry hooks so mental‑state variables (load, tension, activation) can drive visible structural deformation.

### Description
- Neuron meshes and LOD: rebuilt neuron pipeline to provide shape‑coded LOD icons and higher-fidelity morphologies, activity-driven membrane displacement and soma pulse behavior, and procedural tapered branch generation (file: `docs/js/neuro/neuro_ui_3d_neuron.js`).
- Brain shell improvements: added region inference and per-region gyri/sulci noise profiles, region-aware displacement application, and a new `updateMesh(geometry, time, state)` lifecycle to animate vertex displacements from state (file: `docs/js/neuro/neuro_ui_3d_geometry.js`).
- Synapse connection cues: draw directional arrowheads, myelination-like segment markers for strong connections, and dashed/thin structural cues for weak connections so connectivity semantics are visible without color (file: `docs/js/neuro/neuro_ui_3d_synapse.js`).
- DNA geometry upgrades: replace flat colored rungs with flattened beam-like rungs that include twist, thickness variance, hatch marks, and lighting for major/minor groove readability, reducing the need for color-only base-pair identification (file: `docs/js/genetic/genetic_ui_3d_dna.js`).
- Helix topology: modulated helix radius per base-pair to make major/minor groove asymmetry structurally visible (file: `docs/js/genetic/genetic_ui_3d_geometry.js`).

### Testing
- Performed static syntax checks with Node: `node --check docs/js/neuro/neuro_ui_3d_neuron.js`, `node --check docs/js/neuro/neuro_ui_3d_geometry.js`, `node --check docs/js/neuro/neuro_ui_3d_synapse.js`, `node --check docs/js/genetic/genetic_ui_3d_dna.js`, and `node --check docs/js/genetic/genetic_ui_3d_geometry.js`, all of which succeeded.
- No browser render/screenshot testing was available in this environment, so visual verification should be performed in the target runtime to confirm grayscale/readability and animation behaviors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c812eb115c8328902bb57f8f3ff085)