### PR TITLE
Resolve Syntax Errors in Neuro Visualization Modules

### DIFF
--- a/docs/js/brain_mesh_realistic.js
+++ b/docs/js/brain_mesh_realistic.js
@@ -44,7 +44,7 @@
                     z = deformed.z * baseRadius;
 
                     // Determine region
-                    const region = this.determineRegion(x / baseRadius, y / baseRadius, z / baseRadius);
+                    let region = this.determineRegion(x / baseRadius, y / baseRadius, z / baseRadius);
 
                     // Add cortical folds (gyri and sulci)
                     const folds = this.addCorticalFolds(x, y, z, baseRadius, region);
@@ -61,7 +61,7 @@
                     };
 
                     // Determine region
-                    const region = this.determineRegion(x / baseRadius, y / baseRadius, z / baseRadius);
+                    region = this.determineRegion(x / baseRadius, y / baseRadius, z / baseRadius);
 
                     brain.vertices.push({ x, y, z, normal, region });
                 }

--- a/docs/js/neuro/neuro_ui_3d_neuron.js
+++ b/docs/js/neuro/neuro_ui_3d_neuron.js
@@ -145,34 +145,33 @@
                 const litG = Math.min(255, g * intensity);
                 const litB = Math.min(255, b * intensity);
 
-                    ctx.fillStyle = `rgba(${litR}, ${litG}, ${litB}, ${alpha})`;
+                ctx.fillStyle = `rgba(${litR}, ${litG}, ${litB}, ${alpha})`;
 
-                    // --- Structural Neuron Shading ---
-                    ctx.save();
-                    ctx.beginPath();
-                    ctx.moveTo(v1.x, v1.y);
-                    ctx.lineTo(v2.x, v2.y);
-                    ctx.lineTo(v3.x, v3.y);
-                    ctx.closePath();
-                    ctx.fill();
+                // --- Structural Neuron Shading ---
+                ctx.save();
+                ctx.beginPath();
+                ctx.moveTo(v1.x, v1.y);
+                ctx.lineTo(v2.x, v2.y);
+                ctx.lineTo(v3.x, v3.y);
+                ctx.closePath();
+                ctx.fill();
 
-                    // Pattern overlay for accessibility - Reinforced distinctions
-                    if (type === 'pyramidal') {
-                        // Sharp wireframe highlight for pyramidals
-                        ctx.strokeStyle = `rgba(255, 255, 255, ${alpha * 0.6})`;
-                        ctx.lineWidth = 1.0;
-                        ctx.stroke();
-                    } else {
-                        // Soft stipple effect for stellates
-                        if (Math.random() < 0.3) {
-                            ctx.fillStyle = `rgba(255, 255, 255, ${alpha * 0.4})`;
-                            ctx.beginPath();
-                            ctx.arc(v1.x, v1.y, 1, 0, Math.PI * 2);
-                            ctx.fill();
-                        }
+                // Pattern overlay for accessibility - Reinforced distinctions
+                if (type === 'pyramidal') {
+                    // Sharp wireframe highlight for pyramidals
+                    ctx.strokeStyle = `rgba(255, 255, 255, ${alpha * 0.6})`;
+                    ctx.lineWidth = 1.0;
+                    ctx.stroke();
+                } else {
+                    // Soft stipple effect for stellates
+                    if (Math.random() < 0.3) {
+                        ctx.fillStyle = `rgba(255, 255, 255, ${alpha * 0.4})`;
+                        ctx.beginPath();
+                        ctx.arc(v1.x, v1.y, 1, 0, Math.PI * 2);
+                        ctx.fill();
                     }
-                    ctx.restore();
                 }
+                ctx.restore();
             });
         },
 

--- a/tests/unit/js_test_models.js
+++ b/tests/unit/js_test_models.js
@@ -249,7 +249,6 @@
         await new Promise(resolve => setTimeout(resolve, 1000));
         loadingOverlay.style.display = 'none';
 
-<<<<<<< HEAD
         try {
             const section1 = document.createElement('section'); section1.className = 'wixui-section';
             section1.appendChild(document.createElement('div'));
@@ -258,21 +257,9 @@
             const sectionInner = document.createElement('section'); div2_1.appendChild(sectionInner);
             const idiv1 = document.createElement('div'); sectionInner.appendChild(idiv1);
             idiv1.appendChild(document.createElement('div')); idiv1.appendChild(document.createElement('div'));
-            const targetDiv = document.createElement('div'); targetDiv.id = 'model-target';
+            const targetDiv = document.createElement('div'); targetDiv.id = "model-target"; targetDiv.style.height = "800px"; targetDiv.style.minHeight = "800px";
             sectionInner.appendChild(targetDiv);
             modelContainer.appendChild(section1);
-=======
-        const section1 = document.createElement('section'); section1.className = 'wixui-section';
-        section1.appendChild(document.createElement('div'));
-        const div2 = document.createElement('div'); section1.appendChild(div2);
-        const div2_1 = document.createElement('div'); div2.appendChild(div2_1);
-        const sectionInner = document.createElement('section'); div2_1.appendChild(sectionInner);
-        const idiv1 = document.createElement('div'); sectionInner.appendChild(idiv1);
-        idiv1.appendChild(document.createElement('div')); idiv1.appendChild(document.createElement('div'));
-        const targetDiv = document.createElement('div'); targetDiv.id = "model-target"; targetDiv.style.height = "800px"; targetDiv.style.minHeight = "800px";
-        sectionInner.appendChild(targetDiv);
-        modelContainer.appendChild(section1);
->>>>>>> monochromatic-accessibility-fix-411015576853214547
 
             const script = document.createElement('script');
             script.src = `${baseUrl}js/${model.js}`;


### PR DESCRIPTION
I have addressed the reported syntax errors in the neuro visualization modules. In 'brain_mesh_realistic.js', I resolved a 'const' redeclaration error by updating the variable's declaration to 'let'. In 'neuro_ui_3d_neuron.js', I removed an erroneous extra closing brace that was breaking a 'forEach' loop. Additionally, I identified and fixed a critical syntax error in the 'js_test_models.js' test harness caused by leftover merge conflict markers. All fixes have been verified through automated syntax checks, unit tests, and visual validation via Playwright to ensure the 3D models load correctly in the browser.

---
*PR created automatically by Jules for task [7264060456065444427](https://jules.google.com/task/7264060456065444427) started by @drtamarojgreen*