### PR TITLE
Mark facial helpers non-renderable; refine ear and iris assets; enforce render safety

### DIFF
--- a/scripts/blender/movie/4/assets_v4/facial_utilities_v4.py
+++ b/scripts/blender/movie/4/assets_v4/facial_utilities_v4.py
@@ -21,6 +21,11 @@ def _smooth_all(obj):
     for p in obj.data.polygons:
         p.use_smooth = True
 
+def _set_non_render_helper(obj):
+    """Mark rig helper geometry as non-renderable guide-only content."""
+    obj.hide_render = True
+    obj.display_type = 'WIRE'
+
 
 def _new_obj(name, mesh_name, armature, bone_name):
     """Create a new mesh object parented to a bone."""
@@ -198,6 +203,7 @@ def _build_nose_tip(name, armature, bone_name, bark_material):
 
     obj.data.materials.append(bark_material)
     _smooth_all(obj)
+    _set_non_render_helper(obj)
     return obj
 
 
@@ -231,6 +237,7 @@ def _build_nose_ala(name, armature, bone_name, bark_material, side="L"):
 
     obj.data.materials.append(bark_material)
     _smooth_all(obj)
+    _set_non_render_helper(obj)
     return obj
 
 
@@ -264,6 +271,7 @@ def _build_lip_corner(name, armature, bone_name, bark_material, side="L"):
 
     obj.data.materials.append(bark_material)
     _smooth_all(obj)
+    _set_non_render_helper(obj)
     return obj
 
 
@@ -284,10 +292,10 @@ def _build_ear(name, armature, bone_name, bark_material, side="L"):
 
     Construction approach
     ─────────────────────
-    Start with a UV sphere (radius 0.065).  Deform every vertex:
-      1. Flatten depth  (Y *= 0.22)  → thin plate
-      2. Widen slightly (X *= 0.75)
-      3. Elongate       (Z *= 1.25)  → taller than wide
+    Start with a UV sphere (radius 0.10).  Deform every vertex:
+      1. Flatten depth  (Y *= 0.18)  → thin plate
+      2. Preserve width (X *= 0.95)
+      3. Elongate       (Z *= 1.55)  → taller than wide
       4. Helix rim:  verts near the outer edge get Y pushed back (outward)
          to create the rolled-over rim.
       5. Concha scoop: verts near centre get Y pushed forward (inward)
@@ -309,46 +317,46 @@ def _build_ear(name, armature, bone_name, bark_material, side="L"):
     bm = bmesh.new()
 
     # ── Main ear cup (deformed sphere) ────────────────────────────────────
-    bmesh.ops.create_uvsphere(bm, u_segments=24, v_segments=20, radius=0.065)
+    bmesh.ops.create_uvsphere(bm, u_segments=30, v_segments=24, radius=0.10)
 
     for v in bm.verts:
         ox, oy, oz = v.co.x, v.co.y, v.co.z
 
         # 1. Basic shape squash
-        v.co.x = ox * 0.75
-        v.co.y = oy * 0.22       # very flat
-        v.co.z = oz * 1.25       # taller
+        v.co.x = ox * 0.95
+        v.co.y = oy * 0.18       # very flat ear plate
+        v.co.z = oz * 1.55       # taller, more mammalian silhouette
 
         # 2. Helix rim — lateral edge verts (|x| large) roll back in +Y
         lateral = abs(ox)        # use original x before squash
-        if lateral > 0.04:
-            rim_fac = (lateral - 0.04) / 0.025   # 0→1 as we reach the edge
+        if lateral > 0.05:
+            rim_fac = (lateral - 0.05) / 0.04    # 0→1 as we reach the edge
             rim_fac = max(0.0, min(1.0, rim_fac))
-            v.co.y += rim_fac * 0.018             # roll outward (+Y = back)
+            v.co.y += rim_fac * 0.03              # stronger rolled helix
 
         # 3. Concha bowl — central verts scoop inward (-Y = forward into head)
         dist_centre = math.sqrt(ox*ox + oz*oz)
-        if dist_centre < 0.035:
-            bowl_fac = 1.0 - (dist_centre / 0.035)
-            v.co.y -= bowl_fac * 0.014            # hollow cup forward
+        if dist_centre < 0.05:
+            bowl_fac = 1.0 - (dist_centre / 0.05)
+            v.co.y -= bowl_fac * 0.026            # deeper bowl
 
         # 4. Antihelix ridge — a secondary ridge ~60 % of the way from
         #    centre to edge, elevated in Z slightly
-        if 0.020 < dist_centre < 0.040 and oz > 0:
-            antihelix_fac = 1.0 - abs(dist_centre - 0.030) / 0.010
+        if 0.030 < dist_centre < 0.070 and oz > 0:
+            antihelix_fac = 1.0 - abs(dist_centre - 0.050) / 0.020
             antihelix_fac = max(0.0, min(1.0, antihelix_fac))
-            v.co.z += antihelix_fac * 0.010
+            v.co.z += antihelix_fac * 0.02
 
         # 5. Lower lobe — bottom verts (oz < -0.04) rounded and widened
-        if oz < -0.04:
-            lobe_fac = min(1.0, (abs(oz) - 0.04) / 0.025)
-            v.co.x *= (1.0 + lobe_fac * 0.3)     # wider lobe
-            v.co.y += lobe_fac * 0.006            # slight back-tilt
+        if oz < -0.05:
+            lobe_fac = min(1.0, (abs(oz) - 0.05) / 0.045)
+            v.co.x *= (1.0 + lobe_fac * 0.45)    # fuller lobe
+            v.co.y += lobe_fac * 0.01            # slight back-tilt
 
     # ── Tragus nub (small sphere at lower-front of canal) ────────────────
-    tragus_loc = mathutils.Vector((x_sign * 0.010, -0.016, -0.028))
+    tragus_loc = mathutils.Vector((x_sign * 0.014, -0.026, -0.040))
     tret = bmesh.ops.create_uvsphere(bm, u_segments=8, v_segments=8,
-                                     radius=0.012,
+                                     radius=0.016,
                                      matrix=mathutils.Matrix.Translation(tragus_loc))
     # Flatten tragus in Y
     for v in tret['verts']:
@@ -397,6 +405,7 @@ def _build_chin(name, armature, bone_name, bark_material):
 
     obj.data.materials.append(bark_material)
     _smooth_all(obj)
+    _set_non_render_helper(obj)
     return obj
 
 

--- a/scripts/blender/movie/4/assets_v4/plant_humanoid_v4.py
+++ b/scripts/blender/movie/4/assets_v4/plant_humanoid_v4.py
@@ -115,24 +115,22 @@ def create_iris_material_v4(name, color=(0.49, 0.36, 0.75)):
     node_bsdf = nodes.new('ShaderNodeBsdfPrincipled')
     links.new(node_bsdf.outputs['BSDF'], node_out.inputs['Surface'])
 
-    # -- Coordinates: UV coords are baked into the sphere mesh surface --
-    # 'Generated' maps to the object bounding box — after BONE parenting
-    # the bbox origin is at the bone TAIL (not the sphere centre), so the
-    # gradient is displaced and only the sclera-white region is visible.
-    # 'UV' coords are baked into the mesh topology at build time and are
-    # immune to any world/local/bone-space offset.  The front pole of a
-    # bmesh UV sphere sits at UV (0.5, 0.75) — we centre the mapping there.
+    # -- Coordinates --
+    # NOTE: the procedural eyeball and pupil-disc meshes in this pipeline do
+    # not create an explicit UV layer, so `TexCoord.UV` can collapse to a
+    # constant value and wash the eye to sclera-white. Use Generated space so
+    # the iris ramp remains visible without requiring mesh UV authoring.
     tex_coord = nodes.new('ShaderNodeTexCoord')
     mapping   = nodes.new('ShaderNodeMapping')
     mapping.name = "PupilMapping"           # kept for dialogue_scene_v4 animation
-    links.new(tex_coord.outputs['UV'], mapping.inputs['Vector'])
+    links.new(tex_coord.outputs['Generated'], mapping.inputs['Vector'])
 
     # UV space is 0→1 across the sphere surface (not world-units).
     # Scale (3.5, 3.5, 3.5) makes the QUADRATIC_SPHERE gradient fill
     # roughly the front hemisphere, giving a clear pupil/iris/sclera split.
     # Location centres the gradient on the front pole of the UV sphere.
-    mapping.inputs['Scale'].default_value    = (3.5, 3.5, 3.5)
-    mapping.inputs['Location'].default_value = (-0.75, -1.25, 0.0)
+    mapping.inputs['Scale'].default_value    = (2.8, 2.8, 2.8)
+    mapping.inputs['Location'].default_value = (-0.5, -0.5, 0.0)
 
     grad = nodes.new('ShaderNodeTexGradient')
     grad.gradient_type = 'QUADRATIC_SPHERE'
@@ -149,16 +147,21 @@ def create_iris_material_v4(name, color=(0.49, 0.36, 0.75)):
     elems[0].position = 0.0
     elems[0].color    = (0.0, 0.0, 0.0, 1.0)
 
-    # iris inner edge
-    e1 = elems.new(0.18)
-    e1.color = (color[0] * 0.4, color[1] * 0.4, color[2] * 0.4, 1.0)
+    # iris inner edge (stronger saturation so lavender reads on bright keys)
+    e1 = elems.new(0.14)
+    e1.color = (color[0] * 0.75, color[1] * 0.75, color[2] * 0.85, 1.0)
 
-    # iris outer edge / peak colour
-    e2 = elems.new(0.38)
-    e2.color = (color[0], color[1], color[2], 1.0)
+    # iris outer edge / peak colour (wider band + slightly boosted purple)
+    e2 = elems.new(0.56)
+    e2.color = (
+        min(1.0, color[0] * 1.15),
+        min(1.0, color[1] * 1.05),
+        min(1.0, color[2] * 1.25),
+        1.0
+    )
 
     # sclera boundary — sharp transition
-    e3 = elems.new(0.42)
+    e3 = elems.new(0.62)
     e3.color = (0.95, 0.93, 0.90, 1.0)   # warm white sclera
 
     # element [1] was at position 1.0 by default — keep as sclera white

--- a/scripts/blender/movie/4/render_scene4.py
+++ b/scripts/blender/movie/4/render_scene4.py
@@ -83,6 +83,56 @@ def render_scene4():
     
     # 4. Render Setup
     apply_render_preset(mode)
+
+    def enforce_render_safety():
+        """
+        Keep rig controls out of output even if keyed visibility toggles or
+        viewport-style render paths are used.
+        """
+        hidden_armatures = []
+        hidden_face_helpers = []
+
+        for obj in bpy.data.objects:
+            # Rig bones are carried by armature objects.
+            if obj.type == "ARMATURE":
+                obj.hide_render = True
+                obj.hide_viewport = True
+                obj.show_in_front = False
+                arm_data = getattr(obj, "data", None)
+                if arm_data is not None:
+                    # Extra hardening for viewport/openGL style renders where
+                    # bone overlays/custom shapes can still be drawn.
+                    for attr, value in (
+                        ("display_type", "WIRE"),
+                        ("show_names", False),
+                        ("show_axes", False),
+                        ("show_bone_custom_shapes", False),
+                    ):
+                        if hasattr(arm_data, attr):
+                            setattr(arm_data, attr, value)
+                hidden_armatures.append(obj.name)
+                continue
+
+            # Facial control helpers are bone-parented guide meshes.
+            if obj.parent_type == "BONE":
+                bone_name = obj.parent_bone or ""
+                obj_name = obj.name or ""
+                if (".Ctrl" in bone_name
+                        or "LidCorner" in obj_name
+                        or "Ctrl" in obj_name
+                        or "Flare" in obj_name):
+                    obj.hide_render = True
+                    obj.hide_viewport = True
+                    hidden_face_helpers.append(obj.name)
+
+        if hidden_armatures:
+            print(f"RENDER SAFETY: Hidden armatures: {hidden_armatures}")
+        if hidden_face_helpers:
+            print(f"RENDER SAFETY: Hidden face helpers: {hidden_face_helpers}")
+
+    # Initial safety pass before frame stepping.
+    enforce_render_safety()
+
     output_dir = os.path.join(config.OUTPUT_BASE_DIR, "scene4", mode)
     os.makedirs(output_dir, exist_ok=True)
     
@@ -95,6 +145,8 @@ def render_scene4():
     
     for f in range(start_f, end_f + 1):
         scene.frame_set(f)
+        # Re-apply every frame in case keyframed visibility re-enables helpers.
+        enforce_render_safety()
         
         # Camera Switching
         marker = next((m for m in sorted(scene.timeline_markers, key=lambda x: x.frame, reverse=True) if m.frame <= f), None)


### PR DESCRIPTION
### Motivation

- Prevent rig guide meshes and armatures from appearing in final renders or viewport/OpenGL-style renders.  
- Improve the sculptural quality and scale of the mammal ear and related facial anchor props for a more natural silhouette.  
- Make the procedural iris shader robust to lacking UVs and boost iris visibility/saturation on bright lighting.

### Description

- Add a `_set_non_render_helper` helper in `scripts/blender/movie/4/assets_v4/facial_utilities_v4.py` and call it for several facial guide meshes (nose tip, nose alae, lip corners, chin) to set `hide_render=True` and `display_type='WIRE'`.  
- Overhaul ear generation in `facial_utilities_v4.py` by increasing uv-sphere density and radius, changing base squash/scale factors, and tuning rim, concha bowl, antihelix, lobe shaping and tragus position/size to produce a deeper, fuller ear.  
- Update `create_iris_material_v4` in `scripts/blender/movie/4/assets_v4/plant_humanoid_v4.py` to use `TexCoord.Generated` mapping, adjust `Mapping` `Scale`/`Location`, and reconfigure the iris color ramp positions and colors for a stronger, wider iris band.  
- Add `enforce_render_safety()` in `scripts/blender/movie/4/render_scene4.py` to hard-hide armature objects and bone-parented facial helper meshes (setting `hide_render`, `hide_viewport`, and sanitizing armature display attributes) and call it once before frame stepping and on every frame to guard against keyed visibility or viewport-style render paths.

### Testing

- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d27559b31083289995dca506872654)