### PR TITLE
Fix V5 eye stack: constrain pupil size, add sclera material, and validate scale

### DIFF
--- a/scripts/blender/movie/5/assets_v5/facial_utilities_v5.py
+++ b/scripts/blender/movie/5/assets_v5/facial_utilities_v5.py
@@ -39,8 +39,8 @@ def _new_obj(name, mesh_name, armature, bone_name):
 # PUPIL / IRIS DISC
 # ---------------------------------------------------------------------------
 
-def _build_pupil_disc(name, armature, bone_name, iris_material,
-                      disc_radius=0.5, disc_depth=0.004): # Temporarily set to 0.5m radius for visibility test
+def _build_pupil_disc(name, armature, bone_name,
+                      disc_radius=0.015, disc_depth=0.002):
     """
     Thin disc that sits flush against the eyeball cornea, displaying the
     dark pupil ring on top of the iris shader.
@@ -73,30 +73,10 @@ def _build_pupil_disc(name, armature, bone_name, iris_material,
                           radius1=disc_radius,
                           radius2=disc_radius,
                           depth=disc_depth)
-    
-    # --- TEMPORARY DIAGNOSTIC PRINTS ---
-    x_min_bm_pre = min(v.co.x for v in bm.verts)
-    x_max_bm_pre = max(v.co.x for v in bm.verts)
-    y_min_bm_pre = min(v.co.y for v in bm.verts)
-    y_max_bm_pre = max(v.co.y for v in bm.verts)
-    z_min_bm_pre = min(v.co.z for v in bm.verts)
-    z_max_bm_pre = max(v.co.z for v in bm.verts)
-    print(f"DIAGNOSTIC (BMesh Pre-Transform): X-dim={x_max_bm_pre - x_min_bm_pre:.4f}, Y-dim={y_max_bm_pre - y_min_bm_pre:.4f}, Z-dim={z_max_bm_pre - z_min_bm_pre:.4f}")
-    # --- END TEMPORARY DIAGNOSTIC PRINTS ---
 
     # Rotate 90° around X: cone (along Z) → disc (flat in XZ, normal along +Y).
     rot_mx = mathutils.Euler((math.radians(90), 0, 0)).to_matrix().to_4x4()
     bmesh.ops.transform(bm, matrix=rot_mx, verts=bm.verts)
-    
-    # --- TEMPORARY DIAGNOSTIC PRINTS ---
-    x_min_bm_post = min(v.co.x for v in bm.verts)
-    x_max_bm_post = max(v.co.x for v in bm.verts)
-    y_min_bm_post = min(v.co.y for v in bm.verts)
-    y_max_bm_post = max(v.co.y for v in bm.verts)
-    z_min_bm_post = min(v.co.z for v in bm.verts)
-    z_max_bm_post = max(v.co.z for v in bm.verts)
-    print(f"DIAGNOSTIC (BMesh Post-Transform): X-dim={x_max_bm_post - x_min_bm_post:.4f}, Y-dim={y_max_bm_post - y_min_bm_post:.4f}, Z-dim={z_max_bm_post - z_min_bm_post:.4f}")
-    # --- END TEMPORARY DIAGNOSTIC PRINTS ---
 
     bm.to_mesh(mesh)
     bm.free()
@@ -141,6 +121,12 @@ def _build_pupil_disc(name, armature, bone_name, iris_material,
         con.owner_space  = 'WORLD'
 
     return obj
+
+
+def _validate_pupil_scale(pupil, eyeball):
+    """Hard stop against regressions where pupil grows larger than eyeball."""
+    if max(pupil.dimensions) > max(eyeball.dimensions):
+        raise ValueError("Pupil larger than eyeball — invalid state")
 
 
 # ---------------------------------------------------------------------------
@@ -447,7 +433,7 @@ def _build_chin(name, armature, bone_name, bark_material):
 # MAIN ENTRY POINT
 # ---------------------------------------------------------------------------
 
-def create_facial_props_v5(name, armature, bones_map, iris_material, bark_material):
+def create_facial_props_v5(name, armature, bones_map, iris_material, sclera_material, bark_material):
     """
     Upgraded facial prop creation for V5.
 
@@ -500,7 +486,7 @@ def create_facial_props_v5(name, armature, bones_map, iris_material, bark_materi
                 v.co.y += 0.01
         bm.to_mesh(mesh); bm.free()
 
-        obj.data.materials.append(iris_material)
+        obj.data.materials.append(sclera_material)
         _smooth_all(obj)
         facial_objs[f"Eyeball.{side}"] = obj
 
@@ -511,7 +497,10 @@ def create_facial_props_v5(name, armature, bones_map, iris_material, bark_materi
         bone_name = f"Pupil.Ctrl.{side}"
         if not has_bone(bone_name):
             continue
-        pobj = _build_pupil_disc(name, armature, bone_name, iris_material)
+        pobj = _build_pupil_disc(name, armature, bone_name)
+        eyeball = facial_objs.get(f"Eyeball.{side}")
+        if eyeball:
+            _validate_pupil_scale(pobj, eyeball)
         facial_objs[f"Pupil.{side}"] = pobj
 
     # ====================================================================

--- a/scripts/blender/movie/5/assets_v5/plant_humanoid_v5.py
+++ b/scripts/blender/movie/5/assets_v5/plant_humanoid_v5.py
@@ -170,6 +170,21 @@ def create_iris_material_v5(name, color=(0.36, 0.24, 0.62)):
 
     return mat
 
+
+def create_sclera_material_v5(name):
+    """Simple white sclera material for the eyeball base surface."""
+    mat = bpy.data.materials.new(name=name)
+    mat.use_nodes = True
+    bsdf = mat.node_tree.nodes.get("Principled BSDF")
+    if bsdf:
+        bsdf.inputs["Base Color"].default_value = (1.0, 1.0, 1.0, 1.0)
+        bsdf.inputs["Roughness"].default_value = 0.2
+        if "Specular IOR Level" in bsdf.inputs:
+            bsdf.inputs["Specular IOR Level"].default_value = 0.5
+        elif "Specular" in bsdf.inputs:
+            bsdf.inputs["Specular"].default_value = 0.5
+    return mat
+
 def create_leaf_material_v5(name, color=(0.4, 0.6, 0.2)):
     """Translucent botanical leaf material."""
     mat = bpy.data.materials.new(name=name)
@@ -781,9 +796,10 @@ def create_plant_humanoid_v5(name, location, height_scale=1.0, seed=None):
     bones_map = {b.name: b.name for b in armature_obj.data.bones}
 
     iris_mat = create_iris_material_v5(f"Iris_{name}")
+    sclera_mat = create_sclera_material_v5(f"Sclera_{name}")
     bark_mat = create_bark_material_v5(f"FacialBark_{name}",
                                        color=(0.1, 0.15, 0.05))
 
-    create_facial_props_v5(name, armature_obj, bones_map, iris_mat, bark_mat)
+    create_facial_props_v5(name, armature_obj, bones_map, iris_mat, sclera_mat, bark_mat)
     
     return armature_obj


### PR DESCRIPTION
### Motivation
- Pupil geometry was created at a debug/oversized scale and appeared as a free-floating black sphere instead of a surface-constrained feature of the eyeball.
- Eyeball meshes were using the iris shader rather than a distinct white sclera, causing incorrect appearance.
- A regression guard was needed to prevent pupils from becoming larger than their eyeballs.

### Description
- Reduced the default pupil disc geometry to `disc_radius=0.015` and `disc_depth=0.002` in `_build_pupil_disc` to be physically plausible relative to the `eye_radius` ~ `0.06`m and removed temporary diagnostic prints. (`scripts/blender/movie/5/assets_v5/facial_utilities_v5.py`)
- Kept the pupil as an opaque, dedicated black material and preserved the copy-rotation bone constraint so the disc stays aligned to the eyeball surface. (`scripts/blender/movie/5/assets_v5/facial_utilities_v5.py`)
- Added `_validate_pupil_scale(pupil, eyeball)` and wired it into `create_facial_props_v5` to raise on invalid pupil/eyeball scale relationships. (`scripts/blender/movie/5/assets_v5/facial_utilities_v5.py`)
- Introduced `create_sclera_material_v5` and updated the V5 pipeline to create and pass both iris and sclera materials so eyeballs receive a white sclera material instead of the iris shader, and updated `create_facial_props_v5` signature to accept `sclera_material`. (`scripts/blender/movie/5/assets_v5/plant_humanoid_v5.py`, `scripts/blender/movie/5/assets_v5/facial_utilities_v5.py`)

### Testing
- Successfully ran Python syntax checks with `python -m py_compile scripts/blender/movie/5/assets_v5/facial_utilities_v5.py scripts/blender/movie/5/assets_v5/plant_humanoid_v5.py`, which completed without errors.
- No Blender render/unit test runs were executed in this change; runtime behavior is expected to be validated by existing scene tests (e.g. `scripts/blender/movie/5/tests/test_v5_pupils.py`) in downstream test runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4be9d56cc8328ba60f7dc6dbe02ec)