### PR TITLE
Improve pupil disc placement/validation and add sclera material

### DIFF
--- a/scripts/blender/movie/5/assets_v5/facial_utilities_v5.py
+++ b/scripts/blender/movie/5/assets_v5/facial_utilities_v5.py
@@ -39,11 +39,15 @@ def _new_obj(name, mesh_name, armature, bone_name):
 # PUPIL / IRIS DISC
 # ---------------------------------------------------------------------------
 
-def _build_pupil_disc(name, armature, bone_name, iris_material,
-                      disc_radius=0.5, disc_depth=0.004): # Temporarily set to 0.5m radius for visibility test
+def _build_pupil_disc(name, armature, side,
+                      disc_radius=0.03, disc_depth=0.002,
+                      eye_radius=0.06, surface_offset=0.002):
     """
     Thin disc that sits flush against the eyeball cornea, displaying the
     dark pupil ring on top of the iris shader.
+
+    NOTE: disc_radius is intentionally oversized (0.03m) for current
+    debugging visibility so placement issues can be seen clearly in renders.
 
     Parented to Pupil.L / Pupil.R (structural — inset behind cornea).
     Animated via Pupil.Ctrl.L/R scale for dilation/constriction.
@@ -61,9 +65,8 @@ def _build_pupil_disc(name, armature, bone_name, iris_material,
     default rig already points toward the camera (-Y world → +Y local after
     the bone's rest-pose matrix).
     """
-    side      = bone_name.split('.')[-1]          # 'L' or 'R'
     obj_name  = f"{name}_PupilDisc_{side}"
-    obj, mesh = _new_obj(obj_name, obj_name, armature, bone_name)
+    obj, mesh = _new_obj(obj_name, obj_name, armature, f"Eye.{side}")
 
     bm = bmesh.new()
     # Disc is flat in XZ plane — its face normal is along local +Y.
@@ -73,30 +76,10 @@ def _build_pupil_disc(name, armature, bone_name, iris_material,
                           radius1=disc_radius,
                           radius2=disc_radius,
                           depth=disc_depth)
-    
-    # --- TEMPORARY DIAGNOSTIC PRINTS ---
-    x_min_bm_pre = min(v.co.x for v in bm.verts)
-    x_max_bm_pre = max(v.co.x for v in bm.verts)
-    y_min_bm_pre = min(v.co.y for v in bm.verts)
-    y_max_bm_pre = max(v.co.y for v in bm.verts)
-    z_min_bm_pre = min(v.co.z for v in bm.verts)
-    z_max_bm_pre = max(v.co.z for v in bm.verts)
-    print(f"DIAGNOSTIC (BMesh Pre-Transform): X-dim={x_max_bm_pre - x_min_bm_pre:.4f}, Y-dim={y_max_bm_pre - y_min_bm_pre:.4f}, Z-dim={z_max_bm_pre - z_min_bm_pre:.4f}")
-    # --- END TEMPORARY DIAGNOSTIC PRINTS ---
 
     # Rotate 90° around X: cone (along Z) → disc (flat in XZ, normal along +Y).
     rot_mx = mathutils.Euler((math.radians(90), 0, 0)).to_matrix().to_4x4()
     bmesh.ops.transform(bm, matrix=rot_mx, verts=bm.verts)
-    
-    # --- TEMPORARY DIAGNOSTIC PRINTS ---
-    x_min_bm_post = min(v.co.x for v in bm.verts)
-    x_max_bm_post = max(v.co.x for v in bm.verts)
-    y_min_bm_post = min(v.co.y for v in bm.verts)
-    y_max_bm_post = max(v.co.y for v in bm.verts)
-    z_min_bm_post = min(v.co.z for v in bm.verts)
-    z_max_bm_post = max(v.co.z for v in bm.verts)
-    print(f"DIAGNOSTIC (BMesh Post-Transform): X-dim={x_max_bm_post - x_min_bm_post:.4f}, Y-dim={y_max_bm_post - y_min_bm_post:.4f}, Z-dim={z_max_bm_post - z_min_bm_post:.4f}")
-    # --- END TEMPORARY DIAGNOSTIC PRINTS ---
 
     bm.to_mesh(mesh)
     bm.free()
@@ -119,13 +102,10 @@ def _build_pupil_disc(name, armature, bone_name, iris_material,
     obj.data.materials.append(pupil_mat)
     _smooth_all(obj)
 
-    # -- BONE parenting offset fix ------------------------------------------
-    # With parent_type='BONE' Blender places the child's origin at the bone
-    # HEAD.  No additional offset is needed — (0,0,0) keeps the disc flush
-    # against the cornea surface where the Pupil.Ctrl bone head sits.
-    pupil_bone = armature.data.bones.get(bone_name)
-    if pupil_bone:
-        obj.location = (0.0, 0.0, 0.0)
+    # -- Surface placement ---------------------------------------------------
+    # Lock pupil to eye centerline and place it on the front hemisphere.
+    # In this rig, local -Y is forward for the eye bones.
+    obj.location = (0.0, -(eye_radius - surface_offset), 0.0)
 
     # -- Orientation constraint --------------------------------------------
     # Copy the Eye bone's world rotation so the disc always faces the same
@@ -140,7 +120,29 @@ def _build_pupil_disc(name, armature, bone_name, iris_material,
         con.target_space = 'WORLD'
         con.owner_space  = 'WORLD'
 
+    # Drive pupil dilation from the dedicated control bone.
+    ctrl_bone_name = f"Pupil.Ctrl.{side}"
+    if ctrl_bone_name in armature.data.bones:
+        scl = obj.constraints.new('COPY_SCALE')
+        scl.target = armature
+        scl.subtarget = ctrl_bone_name
+        scl.target_space = 'LOCAL'
+        scl.owner_space = 'LOCAL'
+
     return obj
+
+
+def _validate_pupil_scale(pupil, eyeball):
+    """Hard stop against regressions where pupil grows larger than eyeball."""
+    if max(pupil.dimensions) > max(eyeball.dimensions):
+        raise ValueError("Pupil larger than eyeball — invalid state")
+
+
+def _validate_pupil_placement(pupil, eyeball, eye_radius=0.06, tolerance=0.015):
+    """Require pupil center to remain near the eyeball front surface."""
+    dist = (pupil.matrix_world.translation - eyeball.matrix_world.translation).length
+    if abs(dist - eye_radius) > tolerance:
+        raise ValueError(f"Pupil placement off eyeball surface (dist={dist:.4f}, expected≈{eye_radius:.4f})")
 
 
 # ---------------------------------------------------------------------------
@@ -447,7 +449,7 @@ def _build_chin(name, armature, bone_name, bark_material):
 # MAIN ENTRY POINT
 # ---------------------------------------------------------------------------
 
-def create_facial_props_v5(name, armature, bones_map, iris_material, bark_material):
+def create_facial_props_v5(name, armature, bones_map, iris_material, sclera_material, bark_material):
     """
     Upgraded facial prop creation for V5.
 
@@ -500,7 +502,7 @@ def create_facial_props_v5(name, armature, bones_map, iris_material, bark_materi
                 v.co.y += 0.01
         bm.to_mesh(mesh); bm.free()
 
-        obj.data.materials.append(iris_material)
+        obj.data.materials.append(sclera_material)
         _smooth_all(obj)
         facial_objs[f"Eyeball.{side}"] = obj
 
@@ -508,10 +510,15 @@ def create_facial_props_v5(name, armature, bones_map, iris_material, bark_materi
     # 2.  PUPIL DISCS  (NEW structural)
     # ====================================================================
     for side in ("L", "R"):
-        bone_name = f"Pupil.Ctrl.{side}"
-        if not has_bone(bone_name):
+        eye_bone_name = f"Eye.{side}"
+        if not has_bone(eye_bone_name):
             continue
-        pobj = _build_pupil_disc(name, armature, bone_name, iris_material)
+        pobj = _build_pupil_disc(name, armature, side, eye_radius=eye_radius)
+        eyeball = facial_objs.get(f"Eyeball.{side}")
+        if eyeball:
+            bpy.context.view_layer.update()
+            _validate_pupil_scale(pobj, eyeball)
+            _validate_pupil_placement(pobj, eyeball, eye_radius=eye_radius)
         facial_objs[f"Pupil.{side}"] = pobj
 
     # ====================================================================

--- a/scripts/blender/movie/5/assets_v5/plant_humanoid_v5.py
+++ b/scripts/blender/movie/5/assets_v5/plant_humanoid_v5.py
@@ -170,6 +170,21 @@ def create_iris_material_v5(name, color=(0.36, 0.24, 0.62)):
 
     return mat
 
+
+def create_sclera_material_v5(name):
+    """Simple white sclera material for the eyeball base surface."""
+    mat = bpy.data.materials.new(name=name)
+    mat.use_nodes = True
+    bsdf = mat.node_tree.nodes.get("Principled BSDF")
+    if bsdf:
+        bsdf.inputs["Base Color"].default_value = (1.0, 1.0, 1.0, 1.0)
+        bsdf.inputs["Roughness"].default_value = 0.2
+        if "Specular IOR Level" in bsdf.inputs:
+            bsdf.inputs["Specular IOR Level"].default_value = 0.5
+        elif "Specular" in bsdf.inputs:
+            bsdf.inputs["Specular"].default_value = 0.5
+    return mat
+
 def create_leaf_material_v5(name, color=(0.4, 0.6, 0.2)):
     """Translucent botanical leaf material."""
     mat = bpy.data.materials.new(name=name)
@@ -781,9 +796,10 @@ def create_plant_humanoid_v5(name, location, height_scale=1.0, seed=None):
     bones_map = {b.name: b.name for b in armature_obj.data.bones}
 
     iris_mat = create_iris_material_v5(f"Iris_{name}")
+    sclera_mat = create_sclera_material_v5(f"Sclera_{name}")
     bark_mat = create_bark_material_v5(f"FacialBark_{name}",
                                        color=(0.1, 0.15, 0.05))
 
-    create_facial_props_v5(name, armature_obj, bones_map, iris_mat, bark_mat)
+    create_facial_props_v5(name, armature_obj, bones_map, iris_mat, sclera_mat, bark_mat)
     
     return armature_obj


### PR DESCRIPTION
### Motivation
- Fix pupil disc geometry placement and orientation so discs sit reliably on the eyeball surface and follow eye rotation.
- Remove temporary diagnostic prints and add robust checks to prevent regressions where a pupil could be larger than or misplaced relative to the eyeball.
- Separate the eyeball base surface into a dedicated sclera material instead of reusing the iris material.

### Description
- Updated `_build_pupil_disc` signature to `(_build_pupil_disc(name, armature, side, ...))`, reduced default radii, removed debug prints, and parent the disc to `Eye.{side}` while positioning it flush on the corneal surface using `eye_radius` and `surface_offset`.
- Added orientation via `COPY_ROTATION` targeting `Eye.{side}` and added `COPY_SCALE` driven by `Pupil.Ctrl.{side}` to animate dilation.
- Introduced `_validate_pupil_scale` and `_validate_pupil_placement` to assert pupil size/placement relative to the eyeball and invoked these checks after pupil creation.
- Changed `create_facial_props_v5` signature to accept a `sclera_material` and applied it to eyeball objects instead of the iris material, and updated pupil creation to reference `Eye.{side}` availability.
- Added `create_sclera_material_v5` to `plant_humanoid_v5.py` and updated the caller to create and pass a `sclera_mat` when invoking `create_facial_props_v5`.

### Testing
- Ran the repository's automated unit tests (existing test suite) and the modified modules passed without failures.
- Performed an automated headless Blender facial-props smoke test that instantiated the armature and created eyeballs/pupils using the new `sclera` material and validation checks, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d4be9d56cc8328ba60f7dc6dbe02ec)