### PR TITLE
Fix Blender asset collection membership checks to avoid append/link instability

### DIFF
--- a/scripts/blender/movie/7/asset_manager.py
+++ b/scripts/blender/movie/7/asset_manager.py
@@ -12,7 +12,7 @@ class AssetManager:
 
     def ensure_collection(self, name):
         coll = bpy.data.collections.get(name) or bpy.data.collections.new(name)
-        if coll.name not in bpy.context.scene.collection.children:
+        if bpy.context.scene.collection.children.get(coll.name) is None:
             bpy.context.scene.collection.children.link(coll)
         return coll
 
@@ -45,11 +45,11 @@ class AssetManager:
         imported_objs = []
         for obj in data_to.objects:
             if obj:
-                if obj.name not in coll.objects:
+                if coll.objects.get(obj.name) is None:
                     coll.objects.link(obj)
                 imported_objs.append(obj)
                 for child in obj.children_recursive:
-                    if child.name not in coll.objects:
+                    if coll.objects.get(child.name) is None:
                         coll.objects.link(child)
         return imported_objs
 


### PR DESCRIPTION
### Motivation
- A Blender runtime backtrace implicated asset linking code in `scripts/blender/movie/7/asset_manager.py`, where RNA collection membership checks using `in` produced ambiguous behavior that can lead to unstable append/link operations and segfaults.
- The goal is to make collection membership tests explicit and robust against Blender RNA collection semantics during asset linking.

### Description
- Replaced scene child collection membership test in `ensure_collection` with an explicit key lookup: `bpy.context.scene.collection.children.get(coll.name) is None`.
- Replaced object/child membership checks in `link_assets` with explicit lookups: `coll.objects.get(obj.name) is None` and `coll.objects.get(child.name) is None` before linking.
- Changes are contained in `scripts/blender/movie/7/asset_manager.py` and only affect collection membership and linking logic.

### Testing
- Ran `python -m compileall scripts/blender/movie/7/asset_manager.py` which completed successfully.
- Attempted runtime smoke test with `blender --background --python scripts/blender/movie/7/b/assemble.py -- --help` but the `blender` binary is not available in this environment, so Blender runtime validation could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaa826326083289571f890c1668106)