### PR TITLE
Fix Genetic App 3D UI Errors

### DIFF
--- a/docs/js/genetic/genetic_lighting.js
+++ b/docs/js/genetic/genetic_lighting.js
@@ -115,6 +115,21 @@
             return { r: Math.pow(c.r, 1 / 2.2), g: Math.pow(c.g, 1 / 2.2), b: Math.pow(c.b, 1 / 2.2) };
         },
 
+        toRGBA(color) {
+            return `rgba(${Math.round(color.r)}, ${Math.round(color.g)}, ${Math.round(color.b)}, ${color.a})`;
+        },
+
+        parseColor(hex) {
+            if (typeof hex !== 'string') return hex;
+            const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
+            return result ? {
+                r: parseInt(result[1], 16),
+                g: parseInt(result[2], 16),
+                b: parseInt(result[3], 16),
+                a: 1
+            } : { r: 255, g: 255, b: 255, a: 1 };
+        },
+
         getDirectionalLight() {
             return this.lights.find(l => l.type === 'directional')?.direction || { x: 0.5, y: -0.5, z: 1 };
         }

--- a/docs/js/genetic/genetic_ui_3d.js
+++ b/docs/js/genetic/genetic_ui_3d.js
@@ -120,6 +120,10 @@
             container.appendChild(overlay);
         },
 
+        shouldEvolve() {
+            return this.isEvolving;
+        },
+
         resize() {
             if (!this.canvas) return;
             this.canvas.width = this.canvas.offsetWidth;

--- a/docs/js/genetic/genetic_ui_3d_brain.js
+++ b/docs/js/genetic/genetic_ui_3d_brain.js
@@ -52,7 +52,7 @@
                         facesToDraw.push({ indices, p1, p2, p3, depth: (p1.depth + p2.depth + p3.depth) / 3, normal, region: face.region || v1.region });
                     }
                 }
-            });
+            }
 
             facesToDraw.sort((a, b) => b.depth - a.depth);
 


### PR DESCRIPTION
This PR addresses several critical JavaScript errors reported in the genetic application page. 

1. **SyntaxError**: Fixed a malformed `for` loop in `genetic_ui_3d_brain.js` where a `});` was used instead of a `}`.
2. **Missing UI Methods**: Implemented `shouldEvolve()` in `genetic_ui_3d.js`, which was being called by the main simulation loop but was not defined.
3. **Missing Lighting Utilities**: Implemented `toRGBA()` and `parseColor()` in `genetic_lighting.js`. These utilities are required by the DNA and Chromosome rendering modules to handle color conversions and material applications.

These changes collectively resolve the `TypeError` and `SyntaxError` crashes that were preventing the genetic simulation from loading and rendering correctly. Platform-level cookie domain errors are noted but not addressed as they are internal to the Wix infrastructure and do not block application execution.

---
*PR created automatically by Jules for task [6659097707509666915](https://jules.google.com/task/6659097707509666915) started by @drtamarojgreen*