### PR TITLE
Fix Redundant Eye Creation in Movie 9 Plant Characters

### DIFF
--- a/scripts/blender/movie/9/modeling/plant.py
+++ b/scripts/blender/movie/9/modeling/plant.py
@@ -106,23 +106,6 @@ class PlantModeler(Modeler):
                 t_name = f"Toe.{i}.{side}"
                 self._add_organic_part(bm, mesh_obj, dlayer, 0.04, 0.02, 0.12, (f_loc[0] + (i-2)*0.06, toe_base_y - 0.06, f_loc[2]), t_name, rot=(math.radians(90), 0, 0))
 
-        # Facial Features (Eyes/Iris/Pupil for High-Fidelity Test)
-        head_c = mathutils.Vector((0, 0, torso_h+neck_h+head_r))
-        for side, sx in [("L", 1), ("R", -1)]:
-            eye_pos = head_c + mathutils.Vector((0.15*sx, -head_r*0.9, 0.1))
-            num_faces = len(bm.faces)
-            bmesh.ops.create_uvsphere(bm, u_segments=12, v_segments=12, radius=0.08, matrix=mathutils.Matrix.Translation(eye_pos))
-            bm.faces.ensure_lookup_table()
-            for i in range(num_faces, len(bm.faces)):
-                bm.faces[i].material_index = 2 # Iris
-            
-            pupil_pos = eye_pos + mathutils.Vector((0, -0.07, 0))
-            num_faces = len(bm.faces)
-            bmesh.ops.create_uvsphere(bm, u_segments=8, v_segments=8, radius=0.03, matrix=mathutils.Matrix.Translation(pupil_pos))
-            bm.faces.ensure_lookup_table()
-            for i in range(num_faces, len(bm.faces)):
-                bm.faces[i].material_index = 3 # Pupil
-
         # Foliage Algorithm
         f_cfg = self.p_cfg["foliage"]
         head_center = mathutils.Vector((0, 0, torso_h+neck_h+head_r))

--- a/scripts/blender/movie/9/tests/sdd/cards/WaterCanSpoutAudit.cpp
+++ b/scripts/blender/movie/9/tests/sdd/cards/WaterCanSpoutAudit.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <regex>
 #include "../cpp/util/fact_utils.h"
+#include "../cpp/util/decorator.h"
 
 using namespace Sorrel::Sdd::Util;
 

--- a/scripts/blender/movie/9/tests/sdd/sorrel_checkouts.md
+++ b/scripts/blender/movie/9/tests/sdd/sorrel_checkouts.md
@@ -1,0 +1,6 @@
+# Movie 9 SDD — Sorrel Checkouts
+# Tracks completed and verified work per the SORREL Agent Handbook.
+
+## Completed and Verified
+
+- [x] RedundantEyeAudit: Identified and resolved duplicate eye creation in PlantModeler and PlantRigger. Verified total eye count is 2.


### PR DESCRIPTION
This change resolves an issue in Movie 9 where plant characters appeared to have 4 eyes. The problem was caused by both `PlantModeler` and `PlantRigger` independently creating eye structures. I removed the redundant static mesh eyes from `modeling/plant.py`, deferring to the high-fidelity rigging-layer eyes. 

Additionally, I fixed a build failure in the SDD audit system by adding a missing include to `WaterCanSpoutAudit.cpp` and documented the fix in `sorrel_checkouts.md`.

---
*PR created automatically by Jules for task [8613294847757579930](https://jules.google.com/task/8613294847757579930) started by @drtamarojgreen*