### PR TITLE
Fix Models TOC Navigation to Live Pages

### DIFF
--- a/docs/js/models_toc.js
+++ b/docs/js/models_toc.js
@@ -108,11 +108,19 @@
             grid.className = 'models-toc-grid';
             container.appendChild(grid);
 
-            const models = xmlDoc.querySelectorAll('model');
-            models.forEach(model => {
-                const modelId = model.getAttribute('id');
-                const title = model.querySelector('title').textContent;
-                const url = model.querySelector('url') ? model.querySelector('url').textContent : `/${modelId}`;
+            const models = xmlDoc.getElementsByTagName('model');
+            for (let i = 0; i < models.length; i++) {
+                const model = models[i];
+                const modelId = model.getAttribute('id') || 'unknown';
+
+                const titleElem = model.getElementsByTagName('title')[0];
+                const title = titleElem ? titleElem.textContent.trim() : 'Unknown Model';
+
+                const urlElem = model.getElementsByTagName('url')[0];
+                const rawPath = (urlElem && urlElem.textContent.trim()) ? urlElem.textContent.trim() : `/${modelId}`;
+
+                // Ensure path starts with /
+                const finalPath = rawPath.startsWith('/') ? rawPath : '/' + rawPath;
 
                 // Create Card
                 const card = document.createElement('div');
@@ -146,10 +154,9 @@
                 // Launch Button
                 const launchLink = document.createElement('a');
 
-                // Use the URL as provided in the XML (clean URLs)
-                const path = url.startsWith('/') ? url : '/' + url;
-                const canonicalBase = 'https://greenhousemd.org';
-                launchLink.href = canonicalBase + path;
+                // Absolute URL Construction for Production
+                const canonicalDomain = 'https://www.greenhousemd.org';
+                launchLink.href = canonicalDomain + finalPath;
 
                 const t = (k) => window.GreenhouseModelsUtil ? window.GreenhouseModelsUtil.t(k) : k;
                 launchLink.className = 'greenhouse-btn greenhouse-btn-primary';

--- a/tests/unit/common/test_models_toc.js
+++ b/tests/unit/common/test_models_toc.js
@@ -77,7 +77,7 @@
             window.GreenhouseModelsTOC.config.xmlPath = originalXmlPath;
         });
 
-        TestFramework.it('should generate correct canonical URLs for production', async () => {
+        TestFramework.it('should generate correct live URLs with www subdomain and path', async () => {
             window.GreenhouseModelsTOC.init({ target: '#models-toc-container' });
             await new Promise(resolve => setTimeout(resolve, 100));
 
@@ -86,7 +86,13 @@
                 const card = grid.children[0];
                 const launchLink = card.querySelector('a');
                 if (launchLink) {
-                    assert.contains(launchLink.href, 'greenhousemd.org');
+                    // Verify it contains the www subdomain and the domain
+                    assert.contains(launchLink.href, 'www.greenhousemd.org', 'Link should contain the www subdomain');
+                    assert.isTrue(launchLink.href.startsWith('https://'), 'Link should be an absolute HTTPS URL');
+                    // Verify that a path is actually present (e.g., https://www.greenhousemd.org/genetic)
+                    // The path should not just be the base domain.
+                    const urlObj = new URL(launchLink.href);
+                    assert.isTrue(urlObj.pathname.length > 1, 'URL should include the model path');
                 }
             }
         });


### PR DESCRIPTION
Fixed the navigation failure in the Models Table of Contents (TOC). The issue was caused by a combination of fragile XML parsing and hardcoded apex domain URLs that didn't align with the live site's 'www' subdomain.

I refactored the TOC renderer to robustly extract and sanitize paths from the XML and correctly prepend 'https://www.greenhousemd.org'. I also updated the unit tests to verify these absolute production URLs.

---
*PR created automatically by Jules for task [3956673567677644230](https://jules.google.com/task/3956673567677644230) started by @drtamarojgreen*