### PR TITLE
Fix Syntax Error in Models TOC

### DIFF
--- a/docs/js/models_toc.js
+++ b/docs/js/models_toc.js
@@ -127,9 +127,9 @@
                 card.className = 'model-toc-card';
 
                 // Title Section
-                const titleElem = document.createElement('h3');
-                titleElem.textContent = title;
-                card.appendChild(titleElem);
+                const cardTitleElem = document.createElement('h3');
+                cardTitleElem.textContent = title;
+                card.appendChild(cardTitleElem);
 
                 // Description Container
                 const descContainer = document.createElement('div');
@@ -166,7 +166,7 @@
                 card.appendChild(actionGroup);
 
                 grid.appendChild(card);
-            });
+            }
             console.log('AGENT_DEBUG: TOC rendered with card layout and class-based fix.');
             this.addEventListeners();
         },


### PR DESCRIPTION
Resolved two syntax errors in `docs/js/models_toc.js`:
1. A `const` redeclaration of `titleElem` inside the loop.
2. A stray `});` that should have been `}` closing the for-loop.
Verified the fix with `node -c` and loading the script in the test environment.

---
*PR created automatically by Jules for task [450459724795309375](https://jules.google.com/task/450459724795309375) started by @drtamarojgreen*