### PR TITLE
fix(models): remove eval() and stabilize unit test infrastructure

### DIFF
--- a/docs/js/models_ui_synapse.js
+++ b/docs/js/models_ui_synapse.js
@@ -17,14 +17,27 @@
             let path;
             switch (element.type) {
                 case 'path':
-                    path = new Path2D(GreenhouseModelsUtil.parseDynamicPath(element.path, { w, h, tw, psy }));
+                    // Enhanced path parsing: evaluate expressions within the path string
+                    // Example: "M w/2 psy" -> "M 400 360"
+                    const rawPath = element.path || '';
+                    const processedPath = rawPath.split(/(\s|,)/).map(token => {
+                        const trimmed = token.trim();
+                        if (!trimmed || /^[a-zA-Z]$/.test(trimmed)) return token; // Keep commands like M, L, C, etc.
+                        // Check if it contains variables or arithmetic
+                        if (/\b(w|h|tw|psy)\b|[+\-*/]/.test(trimmed)) {
+                            return GreenhouseModelsUtil.compute(trimmed, { w, h, tw, psy });
+                        }
+                        return token;
+                    }).join('');
+
+                    path = new Path2D(processedPath);
                     if(ctx.fillStyle) ctx.fill(path);
                     if(ctx.strokeStyle) ctx.stroke(path);
                     break;
                 case 'ellipse':
                     ctx.beginPath();
-                    const cx = eval(GreenhouseModelsUtil.parseDynamicPath(element.cx, { w, h, tw, psy }));
-                    const cy = eval(GreenhouseModelsUtil.parseDynamicPath(element.cy, { w, h, tw, psy }));
+                    const cx = GreenhouseModelsUtil.compute(element.cx, { w, h, tw, psy });
+                    const cy = GreenhouseModelsUtil.compute(element.cy, { w, h, tw, psy });
                     ctx.ellipse(cx, cy, element.rx, element.ry, 0, 0, Math.PI * 2);
                     if(ctx.fillStyle) ctx.fill();
                     if(ctx.strokeStyle) ctx.stroke();

--- a/docs/js/models_util.js
+++ b/docs/js/models_util.js
@@ -279,6 +279,65 @@
             return pathString.replace(/\b(w|h|tw|psy)\b/g, match => context[match]);
         },
 
+        /**
+         * @function compute
+         * @description Safely evaluates basic mathematical expressions containing context variables.
+         * Supports +, -, *, / and variables w, h, tw, psy.
+         * @param {string} expr - The expression to evaluate (e.g., "w / 2 + 10")
+         * @param {Object} context - Context object containing variable values.
+         * @returns {number} The evaluated result.
+         */
+        compute(expr, context) {
+            if (typeof expr === 'number') return expr;
+            if (!expr) return 0;
+
+            // 1. Replace variables from context
+            let result = this.parseDynamicPath(expr, context);
+
+            // 2. Remove all whitespace
+            result = result.replace(/\s+/g, '');
+
+            // 3. Simple Tokenization and Shunting-Yard for basic arithmetic
+            // For the scope of Greenhouse, we usually only see simple expressions like "w/2" or "psy"
+            // We'll implement a basic calculator that handles precedence.
+
+            const ops = {
+                '+': (a, b) => a + b,
+                '-': (a, b) => a - b,
+                '*': (a, b) => a * b,
+                '/': (a, b) => a / b
+            };
+            const prec = { '+': 1, '-': 1, '*': 2, '/': 2 };
+
+            const tokens = result.split(/([+\-*/])/).filter(t => t.length > 0);
+            const values = [];
+            const operators = [];
+
+            const applyOp = () => {
+                const op = operators.pop();
+                const b = values.pop();
+                const a = values.pop();
+                values.push(ops[op](a, b));
+            };
+
+            for (let token of tokens) {
+                if (ops[token]) {
+                    while (operators.length > 0 && prec[operators[operators.length - 1]] >= prec[token]) {
+                        applyOp();
+                    }
+                    operators.push(token);
+                } else {
+                    values.push(parseFloat(token));
+                }
+            }
+
+            while (operators.length > 0) {
+                applyOp();
+            }
+
+            return values[0] || 0;
+        },
+
         t(key) {
             const lang = this.currentLanguage;
             // 1. Try direct key lookup in current language


### PR DESCRIPTION
- Replaced eval() in GreenhouseModelsUISynapse with a safe arithmetic evaluator in GreenhouseModelsUtil.
- Implemented robust sticky mocks for simulation configurations (Genetic, Neuro) in a new specialized mock file.
- Enhanced browser mocks with HTMLElement and missing Canvas2D methods.
- Documented remaining test runner scoping issues in docs/genetic_simulations.md.